### PR TITLE
Fix debug site for comments

### DIFF
--- a/back-end/api/api/urls.py
+++ b/back-end/api/api/urls.py
@@ -8,6 +8,7 @@ router.register(r'users', views.UserViewSet)
 router.register(r'groups', views.GroupViewSet)
 router.register(r'authors', views.AuthorViewSet)
 router.register(r'posts', views.PostViewSet)
+router.register(r'comments', views.CommentViewSet)
 router.register(r'followers', views.FollowersViewSet)
 
 # Manually bind viewsets instead of using the router so that we can use POST for updates.
@@ -32,8 +33,9 @@ posts_list = views.PostListViewSet.as_view({
     'get': 'list'
 })
 
+# Should be 'get': 'list', but leave it as retrieve so that the debug site still works.
 comments = views.CommentViewSet.as_view({
-    'get': 'list',
+    'get': 'retrieve',
     'post': 'create'
 })
 

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -73,7 +73,7 @@ class CommentViewSet(viewsets.ModelViewSet):
     serializer_class = CommentSerializer
     lookup_field = '_id'
 
-    def list(self, request, author, posts):
+    def retrieve(self, request, author, posts):
         try:
             queryset = Comment.objects.filter(postId=posts)
             serializer = CommentSerializer(queryset, many=True)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/11599574/108006852-c209ff00-6fb9-11eb-8f67-f42bcc51e686.png)


We do this by using retrieve instead of list in ViewSet. Whenever list is overridden, the debug site page we get from registering with the router does not work.

We can decide later if we want to keep it this way or change it back to retrieve once we've made more progress.