### PR TITLE
Display image for image posts (detail view)

### DIFF
--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import { Post } from '../types/Post';
+import { isImage } from '../helpers/ImageHelper';
 
 interface Props {
   post: Post;
@@ -10,6 +11,15 @@ interface Props {
 
 export default function PostListItem(props:Props) {
   const post: Post = props.post;
+
+  function Content() {
+    if (isImage(post)) {
+      return <img src={post.content}/>
+    } else {
+      return <p>{post.content}</p>
+    }
+  }
+
   return (
     <Modal isOpen={props.isOpen} toggle={props.toggle}>
       <ModalHeader toggle={props.toggle}>{post.title}</ModalHeader>
@@ -17,6 +27,7 @@ export default function PostListItem(props:Props) {
         <h6 className="mb-2 text-muted">By: {post.author}</h6>
         <div>
           <p>{post.description}</p>
+          <Content/>
         </div>
       </ModalBody>
       <ModalFooter>

--- a/front-end/src/helpers/ImageHelper.tsx
+++ b/front-end/src/helpers/ImageHelper.tsx
@@ -1,0 +1,7 @@
+import { Post } from '../types/Post';
+
+const imageTypes = ["application/base64", "image/png;base64", "image/jpeg;base64"]
+
+export function isImage(post: Post): boolean {
+  return imageTypes.includes(post.contentType) 
+}

--- a/front-end/src/types/Post.ts
+++ b/front-end/src/types/Post.ts
@@ -8,6 +8,7 @@ export interface Post {
   visibility: string
   unlisted: boolean
   author: string
+  content: string
   contentType: string
   categories: any // May need to change this later at some point. I'm not super worried about nested objects currently
   published: string


### PR DESCRIPTION
I check contentType and if it's any of the image types, I use an `img` tag instead of a `p` tag to display the content.

Also made sure to add 'content' as a string field on the Post class, something we missed earlier.

![image](https://user-images.githubusercontent.com/11599574/108610712-1ab01200-7395-11eb-9309-e82acb7bc47c.png)
