### PR TITLE
Update get posts endpoint and add basic authentication

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_post_list.py
+++ b/back-end/api/quickstart/tests/endpoints/test_post_list.py
@@ -2,7 +2,9 @@
 Referenced https://realpython.com/test-driven-development-of-a-django-restful-api/"""
 import json
 from rest_framework import status
+from rest_framework.test import APIClient, force_authenticate
 from django.test import TestCase, Client
+from django.contrib.auth.models import User
 from quickstart.models import Author, Post
 from quickstart.serializers import PostSerializer
 from quickstart.tests.helper_test import get_test_author_fields, get_test_post_fields, get_test_partial_post_fields
@@ -11,36 +13,62 @@ client = Client()
 
 class GetPosts(TestCase):
   def setUp(self):
-    self.author1 = Author.objects.create(**get_test_author_fields())
+    self.auth_client = APIClient()
+
+    self.user1 = User.objects.create(username='john', password='doe')
+    self.author1 = Author.objects.create(**get_test_author_fields(), user=self.user1)
     self.post1 = Post.objects.create(
-      **get_test_post_fields(1), author=self.author1
+      **get_test_post_fields(1, visibility="Public", unlisted=False), author=self.author1
     )
     self.post2 = Post.objects.create(
-      **get_test_post_fields(2), author=self.author1
+      **get_test_post_fields(2, visibility="Private", unlisted=False), author=self.author1
     )
-
-    self.author2 = Author.objects.create(**get_test_author_fields())
     self.post3 = Post.objects.create(
-      **get_test_post_fields(3), author=self.author2
+      **get_test_post_fields(3, visibility="Public", unlisted=True), author=self.author1
     )
 
-  def test_get_all_posts(self):
-    response = client.get(f'/api/author/{self.author1.id}/posts/')
+    self.user2 = User.objects.create(username='mary', password='lamb')
+    self.author2 = Author.objects.create(**get_test_author_fields(), user=self.user2)
 
+  def test_get_all_posts_for_myself(self):
+    self.auth_client.force_authenticate(user=self.user1)
+    response = self.auth_client.get(f'/api/author/{self.author1.id}/posts/')
+    
     posts = Post.objects.filter(author=self.author1.id)
     serializer = PostSerializer(posts, many=True)
 
     self.assertEqual(response.data, serializer.data)
     self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+  def test_get_all_posts_for_another_author(self):
+    self.auth_client.force_authenticate(user=self.user2)
+    response = self.auth_client.get(f'/api/author/{self.author1.id}/posts/')
+    
+    posts = Post.objects.filter(author=self.author1.id, visibility="Public", unlisted=False)
+    serializer = PostSerializer(posts, many=True)
+
+    self.assertEqual(response.data, serializer.data)
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+  def test_get_all_posts_unauthorized(self):
+    response = client.get(f'/api/author/{self.author1.id}/posts/')
+
+    self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
 
 class CreatePost(TestCase):
+  
   def setUp(self):
-    self.author = Author.objects.create(**get_test_author_fields())
+    self.auth_client = APIClient()
+
+    self.user = User.objects.create(username='john', password='doe')
+    self.author = Author.objects.create(**get_test_author_fields(), user=self.user)
+
     self.payload = get_test_partial_post_fields(i=1)
     
   def test_create_post(self):
-    response = client.post(
+    self.auth_client.force_authenticate(user=self.user)
+    response = self.auth_client.post(
       f'/api/author/{self.author.id}/posts/',
       data=json.dumps(self.payload),
       content_type='application/json'
@@ -49,3 +77,12 @@ class CreatePost(TestCase):
 
     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
     self.assertEqual(response.data, PostSerializer(post).data)
+
+  def test_create_post_unauthorized(self):
+    response = client.post(
+      f'/api/author/{self.author.id}/posts/',
+      data=json.dumps(self.payload),
+      content_type='application/json'
+    )
+
+    self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/back-end/api/quickstart/tests/helper_test.py
+++ b/back-end/api/quickstart/tests/helper_test.py
@@ -30,14 +30,14 @@ def get_test_comment_fields(i=1):
     'contentType': 'text/plain',
   }
 
-def get_test_post_fields(i=1, visibility="Public"):
+def get_test_post_fields(i=1, visibility="Public", unlisted=False):
   return {
     'title': f'testpost{i}',
     'description': f'i am test post {i}',
     'source': f'source post id{i}',
     'origin': f'origin post id{i}',
     'visibility': visibility,
-    'unlisted': True,
+    'unlisted': unlisted,
     'contentType': 'text/plain',
     'content': 'Hello, I am a test post',
     'categories': '["Testing"]',

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -5,7 +5,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from quickstart.serializers import UserSerializer, GroupSerializer, AuthorSerializer, PostSerializer, FollowSerializer, CommentSerializer, LikeSerializer, InboxSerializer
 from .mixins import MultipleFieldLookupMixin
-from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
 
 


### PR DESCRIPTION
When getting posts for an author, if the queried author is the same as the authenticated/logged in author, we get *all* posts for that author. Otherwise we only get public, unlisted=False posts. 

I've added basic authentication to the whole viewset (so creation of posts requires authentication now as well).

Closes #79.