### PR TITLE
Create edit/create modal

### DIFF
--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -107,7 +107,7 @@ export default function CreateEditPostModal(props: Props){
           })
       }
       else if(props.editFields !== undefined){
-          axios.put(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.editFields.id + "/", data, config)
+          axios.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.editFields.id + "/", data, config)
           .then(res => {
             handleRes(res)
           }).catch(error => {
@@ -118,16 +118,19 @@ export default function CreateEditPostModal(props: Props){
   }
 
   function handleRes(res:AxiosResponse){
-    if (res.status >= 400) {
+    if (res.status >= 300) {
       setShowError(true)
-    } else if (res.status === 201) {
+    } else if (res.status >= 200) {
       if(isCreate){
         const post:Post = res.data;
         if(props.prependToFeed !== undefined){
           props.prependToFeed(post)
         }
+        resetFormAndToggle()
+      } else {
+        // We do not want to wipe the fields on our form when we edit
+        props.toggle()
       }
-      resetFormAndToggle()
     }
   }
 

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -110,6 +110,22 @@ export default function CreateEditPostModal(props: Props){
     }
   }
 
+  //Code from Дмитрий Васильев, https://stackoverflow.com/questions/36280818/how-to-convert-file-to-base64-in-javascript
+  const toBase64 = (file:File) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = error => reject(error);
+  });
+
+  async function fileToImageContent(files:any)
+  { 
+    if(files && files.length >= 1){
+      const result: any = await toBase64(files[0])
+      setContent(result)
+    }
+  }
+
   return (
     <Modal isOpen={props.isModalOpen} toggle={props.toggle}>
     <ModalHeader toggle={props.toggle}>{isCreate ? "Create Post" : "Edit Post"}</ModalHeader>
@@ -118,14 +134,14 @@ export default function CreateEditPostModal(props: Props){
           {showError ? <Alert>Could not modify post</Alert> : null}
           <Form inline={true} onSubmit={e => sendPost(e)}>
             <FormGroup>
-              <Input type="text" name="Title" placeholder="Title" onChange={e => setTitle(e.target.value)}/>
+              <Input type="text" name="Title" placeholder="Title" onChange={e => setTitle(e.target.value)} value={title}/>
             </FormGroup>
             <FormGroup>
-              <Input type="text" name="Description" placeholder="Description" onChange={e => setDesc(e.target.value)}/>
+              <Input type="text" name="Description" placeholder="Description" onChange={e => setDesc(e.target.value)} value={desc}/>
             </FormGroup>
             <FormGroup>
               <Label for="Content Type">Content Type</Label>
-              <select name="Content Type" onChange={e => setContentType(e.target.value)}>
+              <select name="Content Type" onChange={e => setContentType(e.target.value)} value={contentType}>
                 <option value="text/markdown">text/markdown</option>
                 <option value="text/plain">text/plain</option>
                 <option value="application/base64">application/base64</option>
@@ -134,15 +150,17 @@ export default function CreateEditPostModal(props: Props){
               </select>
             </FormGroup>
             <FormGroup>
-              <Input type="text" name="Content" placeholder="Content" onChange={e => setContent(e.target.value)}/>
+              <Input type="text" name="Content" placeholder="Content" onChange={e => setContent(e.target.value)} value={content}/>
+              <Input type="file" name="File" placeholder="File" onChange={e => fileToImageContent(e.target.files)}/>
             </FormGroup>
             <FormGroup>
+              {/* TODO: Two way bindings for categories */}
               <Input type="text" name="Categories" placeholder="Categories" onChange={e => parseCategories(e.target.value)}/>
             </FormGroup>
             <FormGroup>
-              <Input id="Visibility" type="checkbox" name="Visibility" placeholder="Unlisted" onChange={e => changeVisibility(e.target.checked)}/>
+              <Input id="Visibility" type="checkbox" name="Visibility" placeholder="Visibility" onChange={e => changeVisibility(e.target.checked)} defaultChecked={visibility==="Friends"}/>
               <Label for="Visibility">Private</Label>
-              <Input id="Unlisted" type="checkbox" name="Unlisted" placeholder="Unlisted" onChange={e => setUnlisted(e.target.checked)}/>
+              <Input id="Unlisted" type="checkbox" name="Unlisted" placeholder="Unlisted" onChange={e => setUnlisted(e.target.checked)} defaultChecked={unlisted}/>
               <Label for="Unlisted">Unlisted</Label>
             </FormGroup>
             <FormGroup>

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -107,7 +107,7 @@ export default function CreateEditPostModal(props: Props){
           })
       }
       else if(props.editFields !== undefined){
-          axios.put(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.editFields.id, data, config)
+          axios.put(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.editFields.id + "/", data, config)
           .then(res => {
             handleRes(res)
           }).catch(error => {

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -9,8 +9,9 @@ interface Props {
   loggedInUser: UserLogin
   toggle: any
   isModalOpen: boolean
+  // These are fields of a post that you want to edit. If this is undefined, the modal will create posts.
+  // If defined, modal will edit an existing post.
   editFields?: Post
-  postFeed?: Post[]
   // Used to append the created post to the feed. Otherwise the feed will be outdated
   prependToFeed?: Function
 }
@@ -19,13 +20,12 @@ interface Props {
  * If editFields is not undefined, then this modal will act as an editing modal
  * @param props 
  */
-
 export default function CreateEditPostModal(props: Props){
 
   const emptyPostFields = {
     title:'',
     description:'',
-    contentType:'Text',
+    contentType:'text/plain',
     content:'',
     categories:[''],
     visibility:'Public',
@@ -51,6 +51,27 @@ export default function CreateEditPostModal(props: Props){
       else {
           setVisibility("Public")
       }
+  }
+  
+  /**
+   * Reset form fields and close modal. To be used when submission is successful
+   */
+  function resetFormAndToggle(){
+    resetFormFields();
+    props.toggle();
+  }
+
+  /**
+   * Reset the forms of the modal, as closing the modal alone does _not_ reset the form fields
+   */
+  function resetFormFields(){
+    setTitle(emptyPostFields.title)
+    setDesc(emptyPostFields.description)
+    setContentType(emptyPostFields.contentType)
+    setContent(emptyPostFields.contentType)
+    setCategories(emptyPostFields.categories)
+    setVisibility(emptyPostFields.visibility)
+    setUnlisted(emptyPostFields.unlisted)
   }
 
   function parseCategories(categories: string) {
@@ -106,7 +127,7 @@ export default function CreateEditPostModal(props: Props){
           props.prependToFeed(post)
         }
       }
-      props.toggle()
+      resetFormAndToggle()
     }
   }
 
@@ -142,8 +163,8 @@ export default function CreateEditPostModal(props: Props){
             <FormGroup>
               <Label for="Content Type">Content Type</Label>
               <select name="Content Type" onChange={e => setContentType(e.target.value)} value={contentType}>
-                <option value="text/markdown">text/markdown</option>
                 <option value="text/plain">text/plain</option>
+                <option value="text/markdown">text/markdown</option>
                 <option value="application/base64">application/base64</option>
                 <option value="image/png;base64">image/png</option>
                 <option value="image/jpeg;base64">image/jpeg</option>

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -154,8 +154,7 @@ export default function CreateEditPostModal(props: Props){
               <Input type="file" name="File" placeholder="File" onChange={e => fileToImageContent(e.target.files)}/>
             </FormGroup>
             <FormGroup>
-              {/* TODO: Two way bindings for categories */}
-              <Input type="text" name="Categories" placeholder="Categories" onChange={e => parseCategories(e.target.value)}/>
+              <Input type="text" name="Categories" placeholder="Categories" onChange={e => parseCategories(e.target.value)} value={categories.join(' ')}/>
             </FormGroup>
             <FormGroup>
               <Input id="Visibility" type="checkbox" name="Visibility" placeholder="Visibility" onChange={e => changeVisibility(e.target.checked)} defaultChecked={visibility==="Friends"}/>

--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -14,16 +14,16 @@ export default function PostListItem(props:Props) {
 
   function Content() {
     if (isImage(post)) {
-      return <img src={post.content}/>
+      return <img src={post.content} style={{width:'100%'}}/>
     } else {
-      return <p>{post.content}</p>
+      return <p style={{width:'100%'}}>{post.content}</p>
     }
   }
 
   return (
     <Modal isOpen={props.isOpen} toggle={props.toggle}>
       <ModalHeader toggle={props.toggle}>{post.title}</ModalHeader>
-      <ModalBody>
+      <ModalBody style={{wordWrap: 'break-word'}}>
         <h6 className="mb-2 text-muted">By: {post.author.displayName}</h6>
         <div>
           <p>{post.description}</p>

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -22,7 +22,7 @@ export default function PostListItem(props:Props) {
   const toggle = () => setIsModalOpen(!isModalOpen);
   const toggleEdit = () => setIsEditModalOpen(!isEditModalOpen);
 
-  const EditCardLink = () => props.isEditable ? <CardLink onClick={()=>{setIsEditModalOpen(true);console.log("DDSDSSDF")}}>Edit</CardLink> : null
+  const EditCardLink = () => props.loggedInUser !== undefined && props.isEditable ? <CardLink onClick={()=>{setIsEditModalOpen(true);console.log("DDSDSSDF")}}>Edit</CardLink> : null
 
   if(props.isEditable || props.isDeletable){
     if(!props.loggedInUser){

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -1,17 +1,34 @@
 import React, { useState } from 'react';
-import { Card, CardBody, CardSubtitle, CardText, CardTitle } from 'reactstrap';
+import { Card, CardBody, CardLink, CardSubtitle, CardText, CardTitle } from 'reactstrap';
 import { Post } from '../types/Post';
+import { UserLogin } from '../types/UserLogin';
+import CreateEditPostModal from './CreateEditPostModal';
 import PostDetailModal from './PostDetailModal';
 
 interface Props {
   post: Post;
+  // true if the user can edit this post
+  isEditable?: boolean;
+  // true if the user can delete the post
+  isDeletable?: boolean;
+  loggedInUser?: UserLogin;
 }
 
 export default function PostListItem(props:Props) {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   const toggle = () => setIsModalOpen(!isModalOpen);
+  const toggleEdit = () => setIsEditModalOpen(!isEditModalOpen);
+
+  const EditCardLink = () => props.isEditable ? <CardLink onClick={()=>{setIsEditModalOpen(true);console.log("DDSDSSDF")}}>Edit</CardLink> : null
+
+  if(props.isEditable || props.isDeletable){
+    if(!props.loggedInUser){
+      console.error('You must supply the logged in user if you are editing or deleting!')
+    }
+  }
 
   const post: Post = props.post;
   return (
@@ -19,13 +36,19 @@ export default function PostListItem(props:Props) {
       <Card>
         {/* TODO: Post image here? */}
         {/* <CardImg top width="100%" src="/assets/318x180.svg" alt="Card image cap" /> */}
-        <CardBody onClick={()=>setIsModalOpen(true)} style={{cursor: 'pointer'}}>
-          <CardTitle tag="h5">{post.title}</CardTitle>
+        <CardBody style={{cursor: 'pointer'}}>
+          <CardTitle onClick={()=>setIsModalOpen(true)} tag="h5">{post.title}</CardTitle>
           <CardSubtitle tag="h6" className="mb-2 text-muted">By: {post.author.displayName}</CardSubtitle>
-          <CardText>{post.description}</CardText>
+          <CardText onClick={()=>setIsModalOpen(true)}>{post.description}</CardText>
+          {EditCardLink()}
         </CardBody>
       </Card>
       <PostDetailModal post={post} toggle={toggle} isOpen={isModalOpen}/>
+      {props.loggedInUser !== undefined && props.isEditable? <CreateEditPostModal 
+                                            loggedInUser={props.loggedInUser}
+                                            toggle={toggleEdit}
+                                            isModalOpen={isEditModalOpen}
+                                            editFields={props.post}/> : null}
     </div>
   );
 }

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -37,6 +37,12 @@ export default function HomePage(props:any) {
     props.history.push('/authors/'+userSearch);
   }
 
+  function preprendToFeed(post:Post){
+    if(postEntries !== undefined){
+      setPostEntries([post, ...postEntries])
+    }
+  }
+
   function CreatePostModal(){
     return(
       <React.Fragment>
@@ -45,6 +51,7 @@ export default function HomePage(props:any) {
           toggle={()=>setIsCreatePostModalOpen(!isCreatePostModalOpen)}
           isModalOpen={isCreatePostModalOpen}
           loggedInUser={props.loggedInUser}
+          prependToFeed={preprendToFeed}
         />
       </React.Fragment>
     )

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -37,7 +37,7 @@ export default function HomePage(props:any) {
     props.history.push('/authors/'+userSearch);
   }
 
-  function preprendToFeed(post:Post){
+  function prependToFeed(post:Post){
     if(postEntries !== undefined){
       setPostEntries([post, ...postEntries])
     }
@@ -51,7 +51,7 @@ export default function HomePage(props:any) {
           toggle={()=>setIsCreatePostModalOpen(!isCreatePostModalOpen)}
           isModalOpen={isCreatePostModalOpen}
           loggedInUser={props.loggedInUser}
-          prependToFeed={preprendToFeed}
+          prependToFeed={prependToFeed}
         />
       </React.Fragment>
     )
@@ -65,7 +65,7 @@ export default function HomePage(props:any) {
     postListElToDisplay = <p>No Entries Found</p>;
   } else {
     postListElToDisplay = postEntries.map((post:Post)=>
-      <PostListItem post={post} key={post.id}/>
+      <PostListItem post={post} key={post.id} isEditable={true} loggedInUser={props.loggedInUser}/>
     );
   }
   console.log(postListElToDisplay)


### PR DESCRIPTION
Add functionality to the create modal to allow it to make edits to posts.

Note that editing posts have not yet been tried out yet, and may need small adjustments for it to work.

Some parts of the modal have already been merged

Can now upload images via file upload.

Added tweaks to `PostDetailModal` to keep elements within the modal

![Screenshot_20210228_110928](https://user-images.githubusercontent.com/28885930/109433552-28d1e400-79ce-11eb-8c1e-6033545b30b6.png)
![Screenshot_20210228_110738](https://user-images.githubusercontent.com/28885930/109433553-2a031100-79ce-11eb-86dc-7e81d427bfe7.png)
