### PR TITLE
Add profile picture to author page

### DIFF
--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -90,7 +90,7 @@ export default function AuthorPage(props: Props) {
 
   const profilePic = () => {
     if (author?.github?.includes("github.com")) {
-      return <CardImg top width="100%" src={author?.github + ".png"} alt="Card image cap" />
+      return <CardImg top width="100%" src={author.github + ".png"} alt="Card image cap" />
     }
 
     return null

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -88,6 +88,14 @@ export default function AuthorPage(props: Props) {
     )
   };
 
+  const profilePic = () => {
+    if (author?.github?.includes("github.com")) {
+      return <CardImg top width="100%" src={author?.github + ".png"} alt="Card image cap" />
+    }
+
+    return null
+  }
+
   if (responseMessage > 299) {
     return (<Container>
       <Alert color="danger">An error occurred! Please try again</Alert>
@@ -99,8 +107,7 @@ export default function AuthorPage(props: Props) {
       <Row className="justify-content-md-center">
         <Col sm={2}>
           <Card body className="text-center">
-            {/* TODO: maybe add profile pic. uncomment line below */}
-            {/* <CardImg top width="100%" src="/assets/318x180.svg" alt="Card image cap" /> */}
+            {profilePic()}
             <CardBody>
               <CardTitle tag="h5">{author?.displayName}</CardTitle>
               <CardLink href={author ? author.github : "#"} >GitHub</CardLink>


### PR DESCRIPTION
If the user's GitHub URL is loosely valid (contains "github.com") then we try to access and display the user's GitHub profile picture by appending .png to the URL.

![image](https://user-images.githubusercontent.com/11599574/109447961-29846d80-7a02-11eb-9053-fc6645a36ef0.png)
