### PR TITLE
Implemented deleting post UI

### DIFF
--- a/front-end/src/components/DeleteModal.tsx
+++ b/front-end/src/components/DeleteModal.tsx
@@ -1,0 +1,70 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import React, { useState } from "react";
+import { Alert, Button, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
+import { UserLogin } from "../types/UserLogin";
+
+interface Props {
+  loggedInUser: UserLogin
+  isModalOpen: boolean
+  toggle: any
+  postID: string
+  removeFromFeed: Function
+}
+
+/**
+ * If editFields is not undefined, then this modal will act as an editing modal
+ * @param props 
+ */
+export default function DeletePostModal(props: Props){
+
+  const [showError, setShowError] = useState(false);
+
+  function deletePost(e:any) {
+      e.preventDefault();
+     
+      const config:AxiosRequestConfig = {
+        auth:{
+          username:props.loggedInUser.username,
+          password:props.loggedInUser.password
+        }
+      }
+
+
+      axios.delete(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.postID, config)
+        .then(res => {
+          handleRes(res)
+        }).catch(error => {
+          setShowError(true)
+        })
+      
+    
+  }
+
+  function handleRes(res:AxiosResponse){
+    if (res.status >= 200) {
+      console.log("success")
+      if(props.removeFromFeed !== undefined){
+        props.removeFromFeed(props.postID)
+        props.toggle()
+      }
+    } else if (res.status >= 400) {
+      setShowError(true)
+    }
+  }
+
+  return (
+    <Modal isOpen={props.isModalOpen} toggle={props.toggle}>
+    <ModalHeader toggle={props.toggle}>{"Delete post"}</ModalHeader>
+    <ModalBody>
+      <div>
+          {showError ? <Alert>Error in deleting post</Alert> : null}
+          {showError ? null : <Button onClick={(e) => deletePost(e)}>Yes</Button>}
+          {showError ? null : <Button onClick={() => {props.toggle()}}>No</Button>}
+      </div>
+    </ModalBody>
+    <ModalFooter>
+      
+    </ModalFooter>
+  </Modal>
+  )
+}

--- a/front-end/src/components/DeleteModal.tsx
+++ b/front-end/src/components/DeleteModal.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 /**
- * If editFields is not undefined, then this modal will act as an editing modal
+ * Delete Post modal, confirmation to delete post as well as removing from list on success
  * @param props 
  */
 export default function DeletePostModal(props: Props){
@@ -29,25 +29,24 @@ export default function DeletePostModal(props: Props){
         }
       }
 
-
+      // Send DELETE request to delete post
       axios.delete(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.postID, config)
         .then(res => {
           handleRes(res)
         }).catch(error => {
           setShowError(true)
         })
-      
-    
   }
 
   function handleRes(res:AxiosResponse){
-    if (res.status >= 200) {
-      console.log("success")
+    if (res.status === 204) {
+      // Successfully deleted post
       if(props.removeFromFeed !== undefined){
         props.removeFromFeed(props.postID)
         props.toggle()
       }
     } else if (res.status >= 400) {
+      // Error in deleting post
       setShowError(true)
     }
   }
@@ -62,9 +61,6 @@ export default function DeletePostModal(props: Props){
           {showError ? null : <Button onClick={() => {props.toggle()}}>No</Button>}
       </div>
     </ModalBody>
-    <ModalFooter>
-      
-    </ModalFooter>
   </Modal>
   )
 }

--- a/front-end/src/components/DeleteModal.tsx
+++ b/front-end/src/components/DeleteModal.tsx
@@ -56,7 +56,7 @@ export default function DeletePostModal(props: Props){
     <ModalHeader toggle={props.toggle}>{"Delete post"}</ModalHeader>
     <ModalBody>
       <div>
-          {showError ? <Alert>Error in deleting post</Alert> : null}
+          {showError ? <Alert color="danger">Error in deleting post</Alert> : null}
           {showError ? null : <Button onClick={(e) => deletePost(e)}>Yes</Button>}
           {showError ? null : <Button onClick={() => {props.toggle()}}>No</Button>}
       </div>

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { Row, Col, Button } from 'reactstrap';
+import CreateEditPostModal from '../components/CreateEditPostModal';
+import PostListItem from '../components/PostListItem';
+import { Post } from '../types/Post';
+
+
+export default function PostList(props:any) {
+
+  const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState<boolean>(false);
+
+  function prependToFeed(post:Post){
+    if(props.postEntries !== undefined){
+      props.setPostEntries([post, ...props.postEntries])
+    }
+  }
+
+  function removeFromFeed(postID: string) {
+    if(props.postEntries !== undefined){
+      props.setPostEntries(props.postEntries.filter((p: Post) => { return postID !== p.id}))
+    }
+  }
+
+  function CreatePostModal(){
+    return(
+      <React.Fragment>
+        <Button onClick={()=>setIsCreatePostModalOpen(true)}>Create Post</Button>
+        <CreateEditPostModal
+          toggle={()=>setIsCreatePostModalOpen(!isCreatePostModalOpen)}
+          isModalOpen={isCreatePostModalOpen}
+          loggedInUser={props.loggedInUser}
+          prependToFeed={prependToFeed}
+        />
+      </React.Fragment>
+    )
+  }
+
+  let postListElToDisplay;
+  if (props.postEntries === undefined){
+    postListElToDisplay = <p>Loading...</p>;
+  } else if (props.postEntries.length === 0) {
+    postListElToDisplay = <p>No Entries Found</p>;
+  } else {
+    postListElToDisplay = props.postEntries.map((post:Post)=>
+      <PostListItem post={post} key={post.id} isEditable={true} isDeletable={true} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed}/>
+    );
+  }
+  console.log(postListElToDisplay);
+
+  return (
+    <Col>
+      <Col>
+        <h3>Feed</h3>
+        {postListElToDisplay}
+      </Col>
+      <Col>
+        {props.loggedInUser ? CreatePostModal() : null}
+      </Col>
+    </Col>
+    );
+}
+

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -7,7 +7,7 @@ import { Post } from '../types/Post';
 
 interface Props {
   postEntries?: Post[];
-  setPostEntries?: Function;
+  setPostEntries: Function;
   loggedInUser?: UserLogin;
 }
 
@@ -15,7 +15,7 @@ interface Props {
  * Post list component to show list of posts
  * @param props 
  */
-export default function PostList(props:any) {
+export default function PostList(props:Props) {
 
   const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState<boolean>(false);
 
@@ -41,7 +41,7 @@ export default function PostList(props:any) {
         <CreateEditPostModal
           toggle={()=>setIsCreatePostModalOpen(!isCreatePostModalOpen)}
           isModalOpen={isCreatePostModalOpen}
-          loggedInUser={props.loggedInUser}
+          loggedInUser={props.loggedInUser as UserLogin}
           prependToFeed={prependToFeed}
         />
       </React.Fragment>

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -50,12 +50,13 @@ export default function PostList(props:any) {
   return (
     <Col>
       <Col>
+        {props.loggedInUser ? CreatePostModal() : null}
+      </Col>
+      <Col>
         <h3>Feed</h3>
         {postListElToDisplay}
       </Col>
-      <Col>
-        {props.loggedInUser ? CreatePostModal() : null}
-      </Col>
+      
     </Col>
     );
 }

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -1,26 +1,39 @@
 import React, { useState } from 'react';
 import { Row, Col, Button } from 'reactstrap';
+import { UserLogin } from '../types/UserLogin';
 import CreateEditPostModal from '../components/CreateEditPostModal';
 import PostListItem from '../components/PostListItem';
 import { Post } from '../types/Post';
 
+interface Props {
+  postEntries?: Post[];
+  setPostEntries?: Function;
+  loggedInUser?: UserLogin;
+}
 
+/**
+ * Post list component to show list of posts
+ * @param props 
+ */
 export default function PostList(props:any) {
 
   const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState<boolean>(false);
 
+  // Add new post to PostList
   function prependToFeed(post:Post){
     if(props.postEntries !== undefined){
       props.setPostEntries([post, ...props.postEntries])
     }
   }
-
+    
+  // Remove post with id postID from list
   function removeFromFeed(postID: string) {
     if(props.postEntries !== undefined){
       props.setPostEntries(props.postEntries.filter((p: Post) => { return postID !== p.id}))
     }
   }
 
+  // Create post button
   function CreatePostModal(){
     return(
       <React.Fragment>
@@ -56,7 +69,6 @@ export default function PostList(props:any) {
         <h3>Feed</h3>
         {postListElToDisplay}
       </Col>
-      
     </Col>
     );
 }

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -61,15 +61,15 @@ export default function PostList(props:Props) {
   console.log(postListElToDisplay);
 
   return (
-    <Col>
-      <Col>
-        {props.loggedInUser ? CreatePostModal() : null}
-      </Col>
+    <>
       <Col>
         <h3>Feed</h3>
         {postListElToDisplay}
       </Col>
-    </Col>
+      <Col>
+        {props.loggedInUser ? CreatePostModal() : null}
+      </Col>
+    </>
     );
 }
 

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { Card, CardBody, CardLink, CardSubtitle, CardText, CardTitle } from 'reactstrap';
+import { Button, Card, CardBody, CardLink, CardSubtitle, CardText, CardTitle } from 'reactstrap';
 import { Post } from '../types/Post';
 import { UserLogin } from '../types/UserLogin';
 import CreateEditPostModal from './CreateEditPostModal';
+import DeletePostModal from './DeleteModal';
 import PostDetailModal from './PostDetailModal';
 
 interface Props {
@@ -12,17 +13,21 @@ interface Props {
   // true if the user can delete the post
   isDeletable?: boolean;
   loggedInUser?: UserLogin;
+  removeFromFeed: Function;
 }
 
 export default function PostListItem(props:Props) {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const toggle = () => setIsModalOpen(!isModalOpen);
   const toggleEdit = () => setIsEditModalOpen(!isEditModalOpen);
+  const toggleDelete = () => setIsDeleteModalOpen(!isDeleteModalOpen);
 
   const EditCardLink = () => props.loggedInUser !== undefined && props.isEditable ? <CardLink onClick={()=>{setIsEditModalOpen(true);console.log("DDSDSSDF")}}>Edit</CardLink> : null
+  const DeleteCardLink = () => props.loggedInUser !== undefined && props.isDeletable ? <CardLink onClick={()=>{setIsDeleteModalOpen(true);}}>Delete</CardLink> : null
 
   if(props.isEditable || props.isDeletable){
     if(!props.loggedInUser){
@@ -41,6 +46,7 @@ export default function PostListItem(props:Props) {
           <CardSubtitle tag="h6" className="mb-2 text-muted">By: {post.author.displayName}</CardSubtitle>
           <CardText onClick={()=>setIsModalOpen(true)}>{post.description}</CardText>
           {EditCardLink()}
+          {DeleteCardLink()}
         </CardBody>
       </Card>
       <PostDetailModal post={post} toggle={toggle} isOpen={isModalOpen}/>
@@ -49,6 +55,12 @@ export default function PostListItem(props:Props) {
                                             toggle={toggleEdit}
                                             isModalOpen={isEditModalOpen}
                                             editFields={props.post}/> : null}
+      {props.loggedInUser !== undefined ? <DeletePostModal 
+                                            loggedInUser={props.loggedInUser}
+                                            isModalOpen={isDeleteModalOpen}
+                                            toggle={toggleDelete}
+                                            postID={props.post.id}
+                                            removeFromFeed={props.removeFromFeed}/> : null}
     </div>
   );
 }

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { UserLogin } from '../types/UserLogin';
+import PostList from '../components/PostList';
 import { Post } from '../types/Post';
 import {
   Col,
@@ -62,38 +63,6 @@ export default function AuthorPage(props: Props) {
     })
   }, []);
 
-  function removeFromFeed(post: Post) {
-    if(postEntries !== undefined){
-      setPostEntries(postEntries.filter((p) => { return post.id !== p.id}))
-    }
-  }
-
-  /* display a card to show posts loading, otherwise show that the user either has
-    no posts or display all posts */
-  const postCards = () => {
-    if (!postEntries) {
-      return (
-        <Card>
-          <CardBody>
-            <CardTitle tag="h5">LOADING POSTS</CardTitle>
-          </CardBody>
-        </Card>
-      )
-    }
-    if (postEntries.length == 0) {
-      return (
-        <Card>
-          <CardBody>
-            <CardTitle tag="h5">No Posts!</CardTitle>
-          </CardBody>
-        </Card>
-      )
-    }
-    return (
-      postEntries.map((post: Post) => <PostListItem post={post} key={post.id} isEditable={true} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed}/>)
-    )
-  };
-
   const profilePic = () => {
     if (author?.github?.includes("github.com")) {
       return <CardImg top width="100%" src={author.github + ".png"} alt="Card image cap" />
@@ -120,9 +89,7 @@ export default function AuthorPage(props: Props) {
             </CardBody>
           </Card>
         </Col>
-        <Col sm={5}>
-          {postCards()}
-        </Col>
+        {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
       </Row>
     </Container>
   );

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -62,6 +62,12 @@ export default function AuthorPage(props: Props) {
     })
   }, []);
 
+  function removeFromFeed(post: Post) {
+    if(postEntries !== undefined){
+      setPostEntries(postEntries.filter((p) => { return post.id !== p.id}))
+    }
+  }
+
   /* display a card to show posts loading, otherwise show that the user either has
     no posts or display all posts */
   const postCards = () => {
@@ -84,7 +90,7 @@ export default function AuthorPage(props: Props) {
       )
     }
     return (
-      postEntries.map((post: Post) => <PostListItem post={post} key={post.id} isEditable={true} loggedInUser={props.loggedInUser} />)
+      postEntries.map((post: Post) => <PostListItem post={post} key={post.id} isEditable={true} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed}/>)
     )
   };
 

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Row, Col, Form, Input, Button } from 'reactstrap';
 import CreateEditPostModal from '../components/CreateEditPostModal';
+import DeletePostModal from '../components/DeleteModal';
 import PostListItem from '../components/PostListItem';
 import { Post } from '../types/Post';
 
@@ -45,6 +46,12 @@ export default function HomePage(props:any) {
     }
   }
 
+  function removeFromFeed(postID: string) {
+    if(postEntries !== undefined){
+      setPostEntries(postEntries.filter((p) => { return postID !== p.id}))
+    }
+  }
+
   function CreatePostModal(){
     return(
       <React.Fragment>
@@ -67,7 +74,7 @@ export default function HomePage(props:any) {
     postListElToDisplay = <p>No Entries Found</p>;
   } else {
     postListElToDisplay = postEntries.map((post:Post)=>
-      <PostListItem post={post} key={post.id} isEditable={true} loggedInUser={props.loggedInUser}/>
+      <PostListItem post={post} key={post.id} isEditable={true} isDeletable={true} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed}/>
     );
   }
   console.log(postListElToDisplay)
@@ -84,7 +91,6 @@ export default function HomePage(props:any) {
         {postListElToDisplay}
       </Col>
       <Col>
-        {/* {props.loggedInUser ? <Button onClick={() => props.history.push('/create_post')}>Create Post</Button> : null} */}
         {props.loggedInUser ? CreatePostModal() : null}
       </Col>
     </Row>

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -2,9 +2,7 @@ import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Row, Col, Form, Input, Button } from 'reactstrap';
-import CreateEditPostModal from '../components/CreateEditPostModal';
-import DeletePostModal from '../components/DeleteModal';
-import PostListItem from '../components/PostListItem';
+import PostList from '../components/PostList';
 import { Post } from '../types/Post';
 
 
@@ -12,10 +10,7 @@ import { Post } from '../types/Post';
 export default function HomePage(props:any) {
 
   const [userSearch,setUserSearch] = useState('');
-
   const [postEntries, setPostEntries] = useState<Post[]|undefined>(undefined);
-
-  const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState<boolean>(false);
 
   useEffect(()=>{
     axios.get(process.env.REACT_APP_API_URL + "/api/public-posts/",).then(res => {
@@ -40,45 +35,6 @@ export default function HomePage(props:any) {
     props.history.push('/authors/'+userSearch);
   }
 
-  function prependToFeed(post:Post){
-    if(postEntries !== undefined){
-      setPostEntries([post, ...postEntries])
-    }
-  }
-
-  function removeFromFeed(postID: string) {
-    if(postEntries !== undefined){
-      setPostEntries(postEntries.filter((p) => { return postID !== p.id}))
-    }
-  }
-
-  function CreatePostModal(){
-    return(
-      <React.Fragment>
-        <Button onClick={()=>setIsCreatePostModalOpen(true)}>Create Post</Button>
-        <CreateEditPostModal
-          toggle={()=>setIsCreatePostModalOpen(!isCreatePostModalOpen)}
-          isModalOpen={isCreatePostModalOpen}
-          loggedInUser={props.loggedInUser}
-          prependToFeed={prependToFeed}
-        />
-      </React.Fragment>
-    )
-  }
-    
-
-  let postListElToDisplay;
-  if (postEntries === undefined){
-    postListElToDisplay = <p>Loading...</p>;
-  } else if (postEntries.length === 0) {
-    postListElToDisplay = <p>No Entries Found</p>;
-  } else {
-    postListElToDisplay = postEntries.map((post:Post)=>
-      <PostListItem post={post} key={post.id} isEditable={true} isDeletable={true} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed}/>
-    );
-  }
-  console.log(postListElToDisplay)
-
   return (
     <Row>
       <Col>
@@ -86,13 +42,7 @@ export default function HomePage(props:any) {
           <Input type="text" name="Author Search" placeholder="Search Authors" onChange={e => onUserSearchChange(e)}/>
         </Form>
       </Col>
-      <Col>
-        <h3>Feed</h3>
-        {postListElToDisplay}
-      </Col>
-      <Col>
-        {props.loggedInUser ? CreatePostModal() : null}
-      </Col>
+      {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
     </Row>
   );
 }


### PR DESCRIPTION
Users can now delete posts from both the homepage and the author page. Refactored PostList into a new component, since both the author page and the home page are using them. Deleting a post will automatically update the list as well.

Delete modal
![image](https://user-images.githubusercontent.com/36487188/109733280-05e53280-7b7c-11eb-81a0-82bdd17e4c39.png)

Error msg
![image](https://user-images.githubusercontent.com/36487188/109733342-26ad8800-7b7c-11eb-8cff-2b38f50b6459.png)
