### PR TITLE
Change TypeScript dependency to 4.1.2

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -20,7 +20,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "reactstrap": "^8.9.0",
-    "typescript": "^4.0.3",
+    "typescript": "^4.1.2",
     "web-vitals": "^0.2.4"
   },
   "scripts": {


### PR DESCRIPTION
This helps me prevent hundreds of linter errors in each tsx file in my VSCode.
Tested the app to make sure that it still works.

https://github.com/facebook/create-react-app/issues/10144#issuecomment-733278351