### PR TITLE
View Other Author's Pages

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
             <Switch>
               <Route exact path="/" render={(props) => <HomePage {...props} loggedInUser={loggedInUser} />} />
               <Route path="/auth" render={(props) => <AuthPage {...props} setLoggedInUser={setLoggedInUser} />} />
-              {loggedInUser && <Route path={`/author/${loggedInUser.authorId}`} render={(props) => <AuthorPage {...props} loggedInUser={loggedInUser} />} />}
+              <Route path="/author/:authorId" render={(props) => <AuthorPage {...props} loggedInUser={loggedInUser}/>}/>
               {/* TODO: hide settings page if not logged in */}
               <Route path="/settings" render={(props) => <SettingsPage loggedInUser={loggedInUser} />} />
               <Route path="/create_post" render={(props) => <CreatePostComponent {...props} loggedInUser={loggedInUser} />} />

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -40,7 +40,7 @@ export default function AuthorPage(props: any) {
     })
 
     // Only get stream if you're viewing your own profile
-    if (props.loggedInUser && props.location.pathname.includes(props.loggedInUser.authorId)) {
+    if (props.loggedInUser) {
       axios.get(authorUrl + "/posts/",
         {
           auth: { // authenticate the GET request
@@ -74,7 +74,7 @@ export default function AuthorPage(props: any) {
   }
 
   const displayPosts = () => {
-    if (props.loggedInUser && author?.id.includes(props.loggedInUser.authorId)) {
+    if (props.loggedInUser) {
       return <PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />
     }
   }

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import { UserLogin } from '../types/UserLogin';
 import PostList from '../components/PostList';
 import { Post } from '../types/Post';
 import {
@@ -16,26 +15,16 @@ import {
   CardText,
   CardLink,
 } from 'reactstrap';
-import PostListItem from '../components/PostListItem';
 import { Author } from '../types/Author';
-import { RouteComponentProps } from 'react-router-dom';
-import { LoggedInUserContext } from '../contexts/LoggedInUserContext';
-
-// interface Props {
-//   props: RouteComponentProps;
-//   loggedInUser: UserLogin | undefined;
-// }
 
 /**
  * Author Page will render and display an author's profile - this includes information
  * about their user account and all the posts they have made
  * @param props 
  */
-// TODO:  - fix navigating from other author --> profile button (self)
-//        - hide "create post" on own profile page?
 export default function AuthorPage(props: any) {
   const authorUrl = process.env.REACT_APP_API_URL + "/api" + props.location.pathname;
-  const [author, setAuthor] = useState<Author|undefined>(undefined);
+  const [author, setAuthor] = useState<Author | undefined>(undefined);
   const [responseMessage, setResponseMessage] = useState(100);
   const [postEntries, setPostEntries] = useState<Post[] | undefined>(undefined);
 
@@ -50,21 +39,22 @@ export default function AuthorPage(props: any) {
       setResponseMessage(500);
     })
 
-    if (props.loggedInUser && props.location.pathname.includes(props.loggedInUser?.authorId)) {
+    // Only get stream if you're viewing your own profile
+    if (props.loggedInUser && props.location.pathname.includes(props.loggedInUser.authorId)) {
       axios.get(authorUrl + "/posts/",
-      {
-        auth: { // authenticate the GET request
-          username: props.loggedInUser.username,
-          password: props.loggedInUser.password,
+        {
+          auth: { // authenticate the GET request
+            username: props.loggedInUser.username,
+            password: props.loggedInUser.password,
+          }
         }
-      }
-    ).then(res => {
-      const posts: Post[] = res.data;
-      setPostEntries(posts);
-    }).catch(err => {
-      console.log("ERROR GETTING POSTS");
-      setResponseMessage(500);
-    })
+      ).then(res => {
+        const posts: Post[] = res.data;
+        setPostEntries(posts);
+      }).catch(err => {
+        console.log("ERROR GETTING POSTS");
+        setResponseMessage(500);
+      })
     };
   }, []);
 

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -18,20 +18,23 @@ import {
 } from 'reactstrap';
 import PostListItem from '../components/PostListItem';
 import { Author } from '../types/Author';
+import { RouteComponentProps } from 'react-router-dom';
+import { LoggedInUserContext } from '../contexts/LoggedInUserContext';
 
-interface Props {
-  loggedInUser: UserLogin | undefined;
-}
+// interface Props {
+//   props: RouteComponentProps;
+//   loggedInUser: UserLogin | undefined;
+// }
 
 /**
  * Author Page will render and display an author's profile - this includes information
  * about their user account and all the posts they have made
  * @param props 
  */
-export default function AuthorPage(props: Props) {
-  // if logged in, assign authorUrl
-  const authorId = props.loggedInUser ? props.loggedInUser.authorId + "/" : "";
-  const authorUrl = process.env.REACT_APP_API_URL + "/api/author/" + authorId;
+// TODO:  - fix navigating from other author --> profile button (self)
+//        - hide "create post" on own profile page?
+export default function AuthorPage(props: any) {
+  const authorUrl = process.env.REACT_APP_API_URL + "/api" + props.location.pathname;
   const [author, setAuthor] = useState<Author|undefined>(undefined);
   const [responseMessage, setResponseMessage] = useState(100);
   const [postEntries, setPostEntries] = useState<Post[] | undefined>(undefined);
@@ -47,11 +50,12 @@ export default function AuthorPage(props: Props) {
       setResponseMessage(500);
     })
 
-    axios.get(process.env.REACT_APP_API_URL + "/api/author/" + authorId + "posts/",
+    if (props.loggedInUser && props.location.pathname.includes(props.loggedInUser?.authorId)) {
+      axios.get(authorUrl + "/posts/",
       {
         auth: { // authenticate the GET request
-          username: props.loggedInUser ? props.loggedInUser.username : "",
-          password: props.loggedInUser ? props.loggedInUser.password : "",
+          username: props.loggedInUser.username,
+          password: props.loggedInUser.password,
         }
       }
     ).then(res => {
@@ -61,6 +65,7 @@ export default function AuthorPage(props: Props) {
       console.log("ERROR GETTING POSTS");
       setResponseMessage(500);
     })
+    };
   }, []);
 
   // Author's profile pic will be the same one from their GitHub
@@ -78,6 +83,12 @@ export default function AuthorPage(props: Props) {
     </Container>)
   }
 
+  const displayPosts = () => {
+    if (props.loggedInUser && author?.id.includes(props.loggedInUser.authorId)) {
+      return <PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />
+    }
+  }
+
   return (
     <Container fluid>
       <Row className="justify-content-md-center">
@@ -90,7 +101,7 @@ export default function AuthorPage(props: Props) {
             </CardBody>
           </Card>
         </Col>
-        {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
+        {author && displayPosts()}
       </Row>
     </Container>
   );


### PR DESCRIPTION
Closes #96 

- Fix not being able to view other author's pages. 
- When you view another author's page, you can't see their stream (unauthorized request when you try, so right now you can only see your own posts since you're authenticated to do so). 
- Introduces weird bug where if you're on someone else's author page, and then try to navigate to your own profile (clicking the "Profile" button on the navbar), you are redirected to the route with your ID but contents are not updated. 

What your profile looks like:
<img width="1783" alt="Screen Shot 2021-03-07 at 5 01 58 PM" src="https://user-images.githubusercontent.com/32996140/110259812-dd3baf00-7f66-11eb-8db9-f6d25bb97106.png">

What other profiles look like:
<img width="1792" alt="Screen Shot 2021-03-07 at 4 49 21 PM" src="https://user-images.githubusercontent.com/32996140/110259599-add87280-7f65-11eb-80ee-b94edc37a572.png">
