### PR TITLE
Add Netlify configuration

### DIFF
--- a/back-end/api/api/settings.py
+++ b/back-end/api/api/settings.py
@@ -146,7 +146,4 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10,
 }
 
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:3000",
-]
-
+CORS_ORIGIN_ALLOW_ALL = True

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base    = "front-end"
-  publish = "front-end/build"
+  publish = "build"
   command = "CI='' npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base    = "front-end"
   publish = "front-end/build"
-  command = "npm run build"
+  command = "CI='' npm run build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  base    = "front-end"
+  publish = "front-end/build"
+  command = "npm run build"


### PR DESCRIPTION
Allows us to deploy the front-end with a fair amount of ease.

We can use a service (Netlify) to automatically publish our front-end with every commit. The current drawback is we need different `.env` files depending if we're production or development. For now we can do this manually.

We can talk about adding more automation/scripts later on.

Changes:

- added config that will allow netlify to automatically build from our git
- added options to Django to open CORS up to everything