### PR TITLE
Add Inbox to Homepage

### DIFF
--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -71,8 +71,6 @@ export default function PostList(props: Props) {
     <>
       <Col>
         {props.loggedInUser ? CreatePostModal() : null}
-      </Col>
-      <Col>
         {postListElToDisplay}
       </Col>
     </>

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Row, Col, Button } from 'reactstrap';
+import { Col, Button } from 'reactstrap';
 import { UserLogin } from '../types/UserLogin';
 import CreateEditPostModal from '../components/CreateEditPostModal';
 import PostListItem from '../components/PostListItem';

--- a/front-end/src/components/PostList.tsx
+++ b/front-end/src/components/PostList.tsx
@@ -15,37 +15,37 @@ interface Props {
  * Post list component to show list of posts
  * @param props 
  */
-export default function PostList(props:Props) {
+export default function PostList(props: Props) {
 
   const [isCreatePostModalOpen, setIsCreatePostModalOpen] = useState<boolean>(false);
 
   // Add new post to PostList
-  function prependToFeed(post:Post){
-    if(props.postEntries !== undefined){
+  function prependToFeed(post: Post) {
+    if (props.postEntries !== undefined) {
       props.setPostEntries([post, ...props.postEntries])
     }
   }
-    
+
   // Remove post with id postID from list
   function removeFromFeed(postID: string) {
-    if(props.postEntries !== undefined){
-      props.setPostEntries(props.postEntries.filter((p: Post) => { return postID !== p.id}))
+    if (props.postEntries !== undefined) {
+      props.setPostEntries(props.postEntries.filter((p: Post) => { return postID !== p.id }))
     }
   }
 
-  function modifyInFeed(post:Post){
-    if(props.postEntries !== undefined){
+  function modifyInFeed(post: Post) {
+    if (props.postEntries !== undefined) {
       props.setPostEntries(props.postEntries.map(original => original.id === post.id ? post : original))
     }
   }
 
   // Create post button
-  function CreatePostModal(){
-    return(
+  function CreatePostModal() {
+    return (
       <>
-        <Button onClick={()=>setIsCreatePostModalOpen(true)}>Create Post</Button>
+        <Button onClick={() => setIsCreatePostModalOpen(true)}>Create Post</Button>
         <CreateEditPostModal
-          toggle={()=>setIsCreatePostModalOpen(!isCreatePostModalOpen)}
+          toggle={() => setIsCreatePostModalOpen(!isCreatePostModalOpen)}
           isModalOpen={isCreatePostModalOpen}
           loggedInUser={props.loggedInUser as UserLogin}
           prependToFeed={prependToFeed}
@@ -56,13 +56,13 @@ export default function PostList(props:Props) {
   }
 
   let postListElToDisplay;
-  if (props.postEntries === undefined){
+  if (props.postEntries === undefined) {
     postListElToDisplay = <p>Loading...</p>;
   } else if (props.postEntries.length === 0) {
     postListElToDisplay = <p>No Entries Found</p>;
   } else {
-    postListElToDisplay = props.postEntries.map((post:Post)=>
-      <PostListItem post={post} key={post.id} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed} modifyInFeed={modifyInFeed}/>
+    postListElToDisplay = props.postEntries.map((post: Post) =>
+      <PostListItem post={post} key={post.id} loggedInUser={props.loggedInUser} removeFromFeed={removeFromFeed} modifyInFeed={modifyInFeed} />
     );
   }
   console.log(postListElToDisplay);
@@ -70,13 +70,12 @@ export default function PostList(props:Props) {
   return (
     <>
       <Col>
-        <h3>Feed</h3>
-        {postListElToDisplay}
-      </Col>
-      <Col>
         {props.loggedInUser ? CreatePostModal() : null}
       </Col>
+      <Col>
+        {postListElToDisplay}
+      </Col>
     </>
-    );
+  );
 }
 

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ export default function HomePage(props: any) {
 
   const [userSearch, setUserSearch] = useState<string>('');
   const [postEntries, setPostEntries] = useState<Post[] | undefined>(undefined);
-  const [followingPostEntries, setFollowingPostEntries] = useState<Post[] | undefined>(undefined);
+  const [inboxEntries, setInboxEntries] = useState<Post[] | undefined>(undefined);
   const [activeTab, setActiveTab] = useState('1');
   const toggle = (tab: any) => {
     if (activeTab !== tab) setActiveTab(tab);
@@ -31,6 +31,18 @@ export default function HomePage(props: any) {
     }).catch(err => {
       console.error(err);
     });
+
+    if (props.loggedInUser) {
+      axios.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/").then(res => {
+        console.log(res.data.items);
+        const inboxPosts: Post[] = res.data.items.filter((p: Post) => { return p.type === 'post'});
+        setInboxEntries(inboxPosts);
+        console.log(inboxPosts);
+      }).catch(err => {
+        console.log("INBOX ERROR")
+        console.error(err);
+      })
+    }
   }, []);
 
   // update on search
@@ -44,63 +56,85 @@ export default function HomePage(props: any) {
     props.history.push(`/authors/${userSearch}`);
   }
 
+  function displayInboxPosts() {
+    if (!inboxEntries || inboxEntries.length === 0) {
+      return (
+        <>
+          <Card body className="text-center">
+            <CardTitle tag="h5">Inbox is empty!</CardTitle>
+          </Card>
+        </>
+      )
+    }
+    return (<PostList postEntries={inboxEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />)
+  }
+
+  function displayLoginMessage() {
+    return (
+      <>
+        <Card body className="text-center">
+          <CardTitle tag="h5">Log in to see your posts from who you follow!</CardTitle>
+        </Card>
+      </>)
+  }
+
   return (
     <>
       {/* <Row> */}
       {/* <Col> */}
       <Container fluid>
         <Row className="justify-content-md-center">
-        <Col sm={2}>
-        <Nav tabs vertical className="justify-content-md-center">
-          <NavItem>
-            <NavLink
-              // className={classnames({ active: activeTab === '1' })}
-              // className={activeTab === '1' ? activeTab : ''}
-              className={`${ true ? activeTab : ''}`}
-              onClick={() => { toggle('1'); }}
-            >Feed</NavLink>
-          </NavItem>
-          <NavItem>
-            <NavLink
-              // className={classnames({ active: activeTab === '2' })}
-              onClick={() => { toggle('2'); }}
-            >Inbox</NavLink>
-          </NavItem>
-          <NavItem>
-            <NavLink
-              // className={classnames({ active: activeTab === '3' })}
-              onClick={() => { toggle('3'); }}
-            >Search</NavLink>
-          </NavItem>
-        </Nav>
-        </Col>
-        <Col className="justify-content-md-center">
-        <TabContent activeTab={activeTab}>
-          <TabPane tabId="1">
-            {/* <Row className="justify-content-md-center"> */}
-              <Col sm={6}>
-                {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
-              </Col>
-            {/* </Row> */}
-          </TabPane>
-          <TabPane tabId="2">
-            {/* <Row className="justify-content-md-center"> */}
-              <Col sm={6}>
-                {<PostList postEntries={followingPostEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
-              </Col>
-            {/* </Row> */}
-          </TabPane>
-          <TabPane tabId="3">
-            {/* <Row className="justify-content-md-center"> */}
-              <Col sm={8}>
-                <Form inline={true} onSubmit={e => searchUsers(e)} className="justify-content-md-center">
-                  <Input type="text" name="Author Search" placeholder="Search Authors" onChange={e => onUserSearchChange(e)} />
-                </Form>
-              </Col>
-            {/* </Row> */}
-          </TabPane>
-        </TabContent>
-        </Col>
+          <Col sm={2}>
+            <Nav tabs vertical className="justify-content-md-center">
+              <NavItem>
+                <NavLink
+                  // className={classnames({ active: activeTab === '1' })}
+                  // className={activeTab === '1' ? activeTab : ''}
+                  className={`${true ? activeTab : ''}`}
+                  onClick={() => { toggle('1'); }}
+                >Feed</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink
+                  // className={classnames({ active: activeTab === '2' })}
+                  onClick={() => { toggle('2'); }}
+                >Inbox</NavLink>
+              </NavItem>
+              <NavItem>
+                <NavLink
+                  // className={classnames({ active: activeTab === '3' })}
+                  onClick={() => { toggle('3'); }}
+                >Search</NavLink>
+              </NavItem>
+            </Nav>
+          </Col>
+          <Col className="justify-content-md-center">
+            <TabContent activeTab={activeTab}>
+              <TabPane tabId="1">
+                {/* <Row className="justify-content-md-center"> */}
+                <Col sm={6}>
+                  {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
+                </Col>
+                {/* </Row> */}
+              </TabPane>
+              <TabPane tabId="2">
+                {/* <Row className="justify-content-md-center"> */}
+                <Col sm={6}>
+                  {props.loggedInUser ? displayInboxPosts() : displayLoginMessage()}
+                </Col>
+                {/* </Row> */}
+              </TabPane>
+              <TabPane tabId="3">
+                {/* <Row className="justify-content-md-center"> */}
+                <Col sm={8}>
+                  <Form inline={true} onSubmit={e => searchUsers(e)} className="justify-content-md-center">
+                    <Input type="text" name="Author Search" placeholder="Search Authors" onChange={e => onUserSearchChange(e)} />
+                  </Form>
+                </Col>
+                {/* </Row> */}
+              </TabPane>
+            </TabContent>
+          </Col>
         </Row>
       </Container>
       {/* </Col> */}

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { Row, Col, Form, Input, Nav, NavItem, NavLink, TabContent, Button, Card, CardText, CardTitle, TabPane, Container } from 'reactstrap';
-import CreateEditPostModal from '../components/CreateEditPostModal';
 import PostList from '../components/PostList';
 import { Post } from '../types/Post';
-import { UserLogin } from '../types/UserLogin';
 
 
 /**
@@ -32,6 +30,7 @@ export default function HomePage(props: any) {
       console.error(err);
     });
 
+    // if logged in, get posts from inbox
     if (props.loggedInUser) {
       axios.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/").then(res => {
         console.log(res.data.items);
@@ -56,6 +55,7 @@ export default function HomePage(props: any) {
     props.history.push(`/authors/${userSearch}`);
   }
 
+  // display empty inbox or inbox posts
   function displayInboxPosts() {
     if (!inboxEntries || inboxEntries.length === 0) {
       return (
@@ -69,6 +69,7 @@ export default function HomePage(props: any) {
     return (<PostList postEntries={inboxEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />)
   }
 
+  // display card that prompts log-in to be able to see inbox posts
   function displayLoginMessage() {
     return (
       <>
@@ -80,16 +81,14 @@ export default function HomePage(props: any) {
 
   return (
     <>
-      {/* <Row> */}
-      {/* <Col> */}
       <Container fluid>
         <Row className="justify-content-md-center">
           <Col sm={2}>
             <Nav tabs vertical className="justify-content-md-center">
               <NavItem>
                 <NavLink
+                  // TODO: consider adding className
                   // className={classnames({ active: activeTab === '1' })}
-                  // className={activeTab === '1' ? activeTab : ''}
                   className={`${true ? activeTab : ''}`}
                   onClick={() => { toggle('1'); }}
                 >Feed</NavLink>
@@ -111,34 +110,26 @@ export default function HomePage(props: any) {
           <Col className="justify-content-md-center">
             <TabContent activeTab={activeTab}>
               <TabPane tabId="1">
-                {/* <Row className="justify-content-md-center"> */}
                 <Col sm={6}>
                   {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
                 </Col>
-                {/* </Row> */}
               </TabPane>
               <TabPane tabId="2">
-                {/* <Row className="justify-content-md-center"> */}
                 <Col sm={6}>
                   {props.loggedInUser ? displayInboxPosts() : displayLoginMessage()}
                 </Col>
-                {/* </Row> */}
               </TabPane>
               <TabPane tabId="3">
-                {/* <Row className="justify-content-md-center"> */}
                 <Col sm={8}>
                   <Form inline={true} onSubmit={e => searchUsers(e)} className="justify-content-md-center">
                     <Input type="text" name="Author Search" placeholder="Search Authors" onChange={e => onUserSearchChange(e)} />
                   </Form>
                 </Col>
-                {/* </Row> */}
               </TabPane>
             </TabContent>
           </Col>
         </Row>
       </Container>
-      {/* </Col> */}
-      {/* </Row> */}
     </>
   );
 }

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -74,7 +74,7 @@ export default function HomePage(props: any) {
     return (
       <>
         <Card body className="text-center">
-          <CardTitle tag="h5">Log in to see your posts from who you follow!</CardTitle>
+          <CardTitle tag="h5">Log in to see posts from who you follow!</CardTitle>
         </Card>
       </>)
   }

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -1,21 +1,29 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import { Row, Col, Form, Input } from 'reactstrap';
+import { Row, Col, Form, Input, Nav, NavItem, NavLink, TabContent, Button, Card, CardText, CardTitle, TabPane, Container } from 'reactstrap';
+import CreateEditPostModal from '../components/CreateEditPostModal';
 import PostList from '../components/PostList';
 import { Post } from '../types/Post';
+import { UserLogin } from '../types/UserLogin';
+
 
 /**
  * Renders the homepage which will display a stream of public posts
  * @param props 
  */
 // https://stackoverflow.com/questions/44118060/react-router-dom-with-typescript/44571743
-export default function HomePage(props:any) {
+export default function HomePage(props: any) {
 
-  const [userSearch,setUserSearch] = useState<string>('');
-  const [postEntries, setPostEntries] = useState<Post[]|undefined>(undefined);
+  const [userSearch, setUserSearch] = useState<string>('');
+  const [postEntries, setPostEntries] = useState<Post[] | undefined>(undefined);
+  const [followingPostEntries, setFollowingPostEntries] = useState<Post[] | undefined>(undefined);
+  const [activeTab, setActiveTab] = useState('1');
+  const toggle = (tab: any) => {
+    if (activeTab !== tab) setActiveTab(tab);
+  }
 
   // get all public posts
-  useEffect(()=>{
+  useEffect(() => {
     axios.get(process.env.REACT_APP_API_URL + "/api/public-posts/",).then(res => {
       console.log(res.data);
       const posts: Post[] = res.data;
@@ -23,27 +31,80 @@ export default function HomePage(props:any) {
     }).catch(err => {
       console.error(err);
     });
-  },[]);
+  }, []);
 
   // update on search
-  function onUserSearchChange(e:any){
+  function onUserSearchChange(e: any) {
     setUserSearch(e.target.value);
   }
 
   // search for authors with the same displayName
-  function searchUsers(e:any){
+  function searchUsers(e: any) {
     e.preventDefault();
     props.history.push(`/authors/${userSearch}`);
   }
-  
+
   return (
-    <Row>
-      <Col>
-        <Form inline={true} onSubmit={e => searchUsers(e)}>
-          <Input type="text" name="Author Search" placeholder="Search Authors" onChange={e => onUserSearchChange(e)}/>
-        </Form>
-      </Col>
-      {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
-    </Row>
+    <>
+      {/* <Row> */}
+      {/* <Col> */}
+      <Container fluid>
+        <Row className="justify-content-md-center">
+        <Col sm={2}>
+        <Nav tabs vertical className="justify-content-md-center">
+          <NavItem>
+            <NavLink
+              // className={classnames({ active: activeTab === '1' })}
+              // className={activeTab === '1' ? activeTab : ''}
+              className={`${ true ? activeTab : ''}`}
+              onClick={() => { toggle('1'); }}
+            >Feed</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink
+              // className={classnames({ active: activeTab === '2' })}
+              onClick={() => { toggle('2'); }}
+            >Inbox</NavLink>
+          </NavItem>
+          <NavItem>
+            <NavLink
+              // className={classnames({ active: activeTab === '3' })}
+              onClick={() => { toggle('3'); }}
+            >Search</NavLink>
+          </NavItem>
+        </Nav>
+        </Col>
+        <Col className="justify-content-md-center">
+        <TabContent activeTab={activeTab}>
+          <TabPane tabId="1">
+            {/* <Row className="justify-content-md-center"> */}
+              <Col sm={6}>
+                {<PostList postEntries={postEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
+              </Col>
+            {/* </Row> */}
+          </TabPane>
+          <TabPane tabId="2">
+            {/* <Row className="justify-content-md-center"> */}
+              <Col sm={6}>
+                {<PostList postEntries={followingPostEntries} setPostEntries={setPostEntries} loggedInUser={props.loggedInUser} />}
+              </Col>
+            {/* </Row> */}
+          </TabPane>
+          <TabPane tabId="3">
+            {/* <Row className="justify-content-md-center"> */}
+              <Col sm={8}>
+                <Form inline={true} onSubmit={e => searchUsers(e)} className="justify-content-md-center">
+                  <Input type="text" name="Author Search" placeholder="Search Authors" onChange={e => onUserSearchChange(e)} />
+                </Form>
+              </Col>
+            {/* </Row> */}
+          </TabPane>
+        </TabContent>
+        </Col>
+        </Row>
+      </Container>
+      {/* </Col> */}
+      {/* </Row> */}
+    </>
   );
 }


### PR DESCRIPTION
Closes #123 

Homepage now consists of 3 tabs: Server/Public Feed, Inbox, and Search.

I manually tested/added posts to author's inboxes so right now the inbox should always be empty unless you go into the admin page and add items/posts manually. 

Also adjusted the `PostList` UI a little bit, but we can tidy it up and make it look nice later.

Public feed looks the same. Inbox feed:
<img width="1789" alt="Screen Shot 2021-03-10 at 5 43 09 PM" src="https://user-images.githubusercontent.com/32996140/110719282-d5c81000-81c9-11eb-91e2-e20ec724ab6c.png">

What it looks like if you're not logged in:
<img width="1786" alt="Screen Shot 2021-03-10 at 5 46 52 PM" src="https://user-images.githubusercontent.com/32996140/110719316-e4aec280-81c9-11eb-837f-fa1d650da81b.png">
Empty inbox feed:
<img width="1792" alt="Screen Shot 2021-03-10 at 5 48 11 PM" src="https://user-images.githubusercontent.com/32996140/110719319-e6788600-81c9-11eb-84bf-4df09b7e0fd2.png">
What search tab looks like:
<img width="1792" alt="Screen Shot 2021-03-10 at 5 43 23 PM" src="https://user-images.githubusercontent.com/32996140/110719324-e8dae000-81c9-11eb-95a0-ed44d1ac2f55.png">
