### PR TITLE
Use partial_update for Post editing in DRF

### DIFF
--- a/back-end/api/api/urls.py
+++ b/back-end/api/api/urls.py
@@ -40,7 +40,7 @@ auth_user = views.AuthUserViewSet.as_view({
 # PUT create a post with that post_id
 posts = views.PostViewSet.as_view({
     'get': 'retrieve',
-    'post': 'update',
+    'post': 'partial_update',
     'delete': 'destroy',
     'put': 'create'
 })

--- a/back-end/api/quickstart/tests/endpoints/test_author.py
+++ b/back-end/api/quickstart/tests/endpoints/test_author.py
@@ -53,6 +53,15 @@ class UpdateAuthorById(TestCase):
     self.assertEqual(serializer.data['id'], str(self.john.id))
     self.assertEqual(serializer.data['type'], self.john.type)
 
+  def test_partial_update_author(self):
+    partial_payload = partial_payload = { 'displayName': 'new name'}
+    response = client.post(
+      f'/api/author/{self.john.id}/',
+      data=json.dumps(partial_payload),
+      content_type='application/json'
+    )
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+
   def test_update_invalid_author(self):
     response = client.post(
       '/api/author/invalidId/',

--- a/back-end/api/quickstart/tests/endpoints/test_posts.py
+++ b/back-end/api/quickstart/tests/endpoints/test_posts.py
@@ -53,6 +53,15 @@ class UpdatePostById(TestCase):
     self.assertEqual(serializer.data['id'], str(self.post.id))
     self.assertEqual(serializer.data['type'], self.post.type)
 
+  def test_partial_update_post(self):
+    partial_payload = { 'description': 'new description'}
+    response = client.post(
+      f'/api/author/{self.author.id}/posts/{self.post.id}/',
+      data=json.dumps(partial_payload),
+      content_type='application/json'
+    )
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+
   def test_update_invalid_post(self):
     response = client.post(
       f'/api/author/{self.author.id}/posts/invalidId/',


### PR DESCRIPTION
We had a bug where posts could not be edited unless every field was sent. (e.g., editing a post that didn't have a description would result in an error). Fixed this by changing DRF to use partial_update instead of just update.

Added tests for this and also for author retroactively.