### PR TITLE
Find likes by checking for substring (post/comment ID) in object field 

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_likes_comment.py
+++ b/back-end/api/quickstart/tests/endpoints/test_likes_comment.py
@@ -20,7 +20,7 @@ class GetLikesForComment(TestCase):
   def test_get_likes_for_comment(self):
     response = client.get(f'/api/author/authorId/posts/postId/comments/{self.test_comment_id}/likes')
 
-    likes = Like.objects.filter(object=self.test_comment_id)
+    likes = Like.objects.filter(object__contains=self.test_comment_id)
     serializer = LikeSerializer(likes, many=True)
 
     self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/back-end/api/quickstart/tests/endpoints/test_likes_post.py
+++ b/back-end/api/quickstart/tests/endpoints/test_likes_post.py
@@ -20,7 +20,7 @@ class GetLikesForPost(TestCase):
   def test_get_likes_for_post(self):
     response = client.get(f'/api/author/authorId/posts/{self.test_post_id}/likes/')
 
-    likes = Like.objects.filter(object=self.test_post_id)
+    likes = Like.objects.filter(object__contains=self.test_post_id)
     serializer = LikeSerializer(likes, many=True)
 
     self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -206,7 +206,7 @@ class LikesPostViewSet(viewsets.ModelViewSet):
 
     # TODO: Author is currently being ignored. Do we need to use it?
     def retrieve(self, request, author, post):
-        likes = Like.objects.filter(object=post)
+        likes = Like.objects.filter(object__contains=post)
         serializer = LikeSerializer(likes, many=True)
 
         return Response({
@@ -224,7 +224,7 @@ class LikesCommentViewSet(viewsets.ModelViewSet):
 
     # TODO: Author+Post is currently being ignored. Do we need to use it?
     def retrieve(self, request, author, post, comment):
-        likes = Like.objects.filter(object=comment)
+        likes = Like.objects.filter(object__contains=comment)
         serializer = LikeSerializer(likes, many=True)
 
         return Response({


### PR DESCRIPTION
Previously, this wouldn't have worked properly because if the "object" field of the Like actually stores an entire URL, and the endpoint `api/author/<str:author>/posts/<str:post>/likes/` would break unless <str:post> was an entire URL, which would still also break unless we encode the URL before sending.

To fix this when people ask for likes for a post/comment, the <str:post> should just be a UUID. Thus, we find all likes where its object field contains this UUID substring. 