### PR TITLE
Add 'api/' and trailing slash to author url

### DIFF
--- a/back-end/api/quickstart/signals.py
+++ b/back-end/api/quickstart/signals.py
@@ -18,7 +18,7 @@ def after_user_signed_up(request, user, **kwargs):
     """
     author = Author.objects.create(user=user, displayName=user.username, github=user.username)
     author.host = str(request.build_absolute_uri('/'))
-    author.url = f'{author.host}author/{author.id}'
+    author.url = f'{author.host}api/author/{author.id}/'
     
     author.save()
 


### PR DESCRIPTION
This makes it so that this author URL can be directly GET'd to retrieve the author information.