### PR TITLE
Match authors/ endpoint with other teams

### DIFF
--- a/back-end/api/api/urls.py
+++ b/back-end/api/api/urls.py
@@ -28,7 +28,7 @@ author = views.AuthorViewSet.as_view({
 })
 
 # Endpoint: /api/authors/
-# GET: retrieve a list of all authors
+# GET: retrieve a list of all authors. Custom endpoint used for searching authors.
 authors = views.AuthorsViewSet.as_view({
     'get': 'list'
 })

--- a/back-end/api/api/urls.py
+++ b/back-end/api/api/urls.py
@@ -9,7 +9,6 @@ from quickstart import views
 
 # Debug site/endpoints that DRF helps us implement.
 router = routers.DefaultRouter()
-router.register(r'authors', views.AuthorViewSet)
 router.register(r'posts', views.PostViewSet)
 router.register(r'comments', views.CommentViewSet)
 router.register(r'followers', views.FollowersViewSet)
@@ -26,6 +25,12 @@ router.register(r'inbox', views.InboxViewSet)
 author = views.AuthorViewSet.as_view({
     'get': 'retrieve',
     'post': 'partial_update',
+})
+
+# Endpoint: /api/authors/
+# GET: retrieve a list of all authors
+authors = views.AuthorsViewSet.as_view({
+    'get': 'list'
 })
 
 # Custom endpoint for retrieving an Author object from a Django User object.
@@ -121,6 +126,7 @@ urlpatterns = [
     path('api/admin/', admin.site.urls),
     # Paths for all our API endpoints
     path('api/author/<str:id>/', author, name='author'),
+    path('api/authors/', authors, name='authors'),
     path('api/public-posts/', public_posts_list, name='public-posts-list'),
     path('api/auth-user/<str:username>/', auth_user, name='auth-user'),
     path('api/author/<str:author>/posts/', posts_list, name='posts-list'),

--- a/back-end/api/quickstart/serializers.py
+++ b/back-end/api/quickstart/serializers.py
@@ -9,7 +9,7 @@ from rest_framework import serializers
 class AuthorSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Author
-        fields = ['id', 'type', 'displayName', 'url', 'github']
+        fields = ['id', 'type', 'displayName', 'url', 'github', 'host']
 
 class PostSerializer(serializers.HyperlinkedModelSerializer):
     author = AuthorSerializer(read_only=True)

--- a/back-end/api/quickstart/tests/endpoints/test_authors.py
+++ b/back-end/api/quickstart/tests/endpoints/test_authors.py
@@ -1,0 +1,27 @@
+import json
+from rest_framework import status
+from django.test import TestCase, Client
+from quickstart.models import Author
+from quickstart.serializers import AuthorSerializer
+from quickstart.tests.helper_test import get_test_author_fields
+
+client = Client()
+
+class GetAuthorById(TestCase):
+  """Tests for getting all Authors at endpoint /api/authors/."""
+  def test_get_authors(self):
+    for i in range(3):
+      Author.objects.create(**get_test_author_fields())
+
+    response = client.get(f'/api/authors/')
+    authors = Author.objects.all()
+    serializer = AuthorSerializer(authors, many=True)
+
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(response.data, serializer.data)
+
+  def test_get_authors_empty(self):
+    response = client.get(f'/api/authors/')
+
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(len(response.data), 0)

--- a/back-end/api/quickstart/tests/endpoints/test_authors.py
+++ b/back-end/api/quickstart/tests/endpoints/test_authors.py
@@ -1,4 +1,3 @@
-import json
 from rest_framework import status
 from django.test import TestCase, Client
 from quickstart.models import Author

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -24,6 +24,19 @@ class AuthorViewSet(viewsets.ModelViewSet):
     # https://stackoverflow.com/questions/56431755/django-rest-framework-urls-without-pk
     lookup_field = 'id'
 
+class AuthorsViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows getting all authors.
+    """
+    queryset = Author.objects.all()
+    serializer_class = AuthorSerializer
+    lookup_field = 'id'
+
+    def list(self, request):
+        authors = Author.objects.all()
+        serializer = AuthorSerializer(authors, many=True)
+
+        return Response(serializer.data)
 
 class AuthUserViewSet(viewsets.ModelViewSet):
     """

--- a/front-end/src/components/AuthorListItem.tsx
+++ b/front-end/src/components/AuthorListItem.tsx
@@ -38,7 +38,7 @@ export default function AuthorListItem(props: Props) {
   return (
     <>
       <div>
-        <h3>{props.author.displayName} {props.author.github}</h3>
+        <h3>{props.author.displayName}</h3>
       </div>
       <div>
         <Link to={{ pathname: `/author/${props.author.id}` }} >

--- a/front-end/src/pages/AuthorResultsPage.tsx
+++ b/front-end/src/pages/AuthorResultsPage.tsx
@@ -23,7 +23,7 @@ export default function AuthorResultsPage(props:any) {
   useEffect(() => {
     axios.get(`${process.env.REACT_APP_API_URL}/api/authors/`)
     .then(response => {
-        const filteredAuthorsResponse = response.data.results.filter((author:Author) => author.displayName === displayName);
+        const filteredAuthorsResponse = response.data.filter((author:Author) => author.displayName === displayName);
         setAuthors(filteredAuthorsResponse);
     })
   }, []);


### PR DESCRIPTION
We had some pagination attributes etc. from the router default endpoint. I've added our own ViewSet to return all authors now and added proper tests as well. 

Result looks like this now:
```javascript
[
    {
        "id": "f9e8eb9e-f30c-44d6-bc1c-a1450543b389",
        "type": "author",
        "displayName": "abc",
        "url": "http://localhost:8000/api/author/f9e8eb9e-f30c-44d6-bc1c-a1450543b389/",
        "github": "abc",
        "host": "http://localhost:8000/"
    },
    {
        "id": "93721ae8-1d9a-4f07-b1d3-d5e640250616",
        "type": "author",
        "displayName": "abc2",
        "url": "http://localhost:8000/api/author/93721ae8-1d9a-4f07-b1d3-d5e640250616/",
        "github": "abc2",
        "host": "http://localhost:8000/"
    }
]
```