### PR TITLE
Follow serialization now gives just author object

### DIFF
--- a/back-end/api/quickstart/serializers.py
+++ b/back-end/api/quickstart/serializers.py
@@ -33,7 +33,7 @@ class FollowSerializer(serializers.HyperlinkedModelSerializer):
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        return ret["sender"]
+        return ret['sender']
 
 
 class LikeSerializer(serializers.HyperlinkedModelSerializer):

--- a/back-end/api/quickstart/serializers.py
+++ b/back-end/api/quickstart/serializers.py
@@ -31,6 +31,10 @@ class FollowSerializer(serializers.HyperlinkedModelSerializer):
         model = Follow
         fields = ['sender']
 
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        return ret["sender"]
+
 
 class LikeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:


### PR DESCRIPTION
Before the serialization for follow objects included the field name from the model. 
```json
{
  "type": "followers",
  "items": [
    {
      "sender": {
        "id": "bededf14-66b1-4e89-8d00-db1cd559f21f",
        "url": "http://localhost:8000/author/bededf14-66b1-4e89-8d00-db1cd559f21f",
        "type": "author",
        "github": "abc1",
        "displayName": "abc1"
      }
    },
    {
      "sender": {
        "id": "3e0f264d-c88f-491a-8b2f-7ac6187497b2",
        "url": "http://localhost:8000/author/3e0f264d-c88f-491a-8b2f-7ac6187497b2",
        "type": "author",
        "github": "abc3",
        "displayName": "abc3"
      }
    }
  ]
}
```

Now the sender field is removed and now returns just a list of follow objects (for a get for a follow it'll just return a single author object):
```json
{
  "type": "followers",
  "items": [
    {
      "id": "bededf14-66b1-4e89-8d00-db1cd559f21f",
      "url": "http://localhost:8000/author/bededf14-66b1-4e89-8d00-db1cd559f21f",
      "type": "author",
      "github": "abc1",
      "displayName": "abc1"
    },
    {
      "id": "3e0f264d-c88f-491a-8b2f-7ac6187497b2",
      "url": "http://localhost:8000/author/3e0f264d-c88f-491a-8b2f-7ac6187497b2",
      "type": "author",
      "github": "abc3",
      "displayName": "abc3"
    }
  ]
}
```