### PR TITLE
Fixed failing test for follows

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_followers.py
+++ b/back-end/api/quickstart/tests/endpoints/test_followers.py
@@ -18,6 +18,8 @@ class GetFollow(TestCase):
   def test_get_valid_follow(self):
     response = client.get(f'/api/author/{self.receiver.id}/followers/{self.sender_id}/')
     serializer = FollowSerializer(self.follow)
+    print(response.data)
+    print(serializer.data)
     self.assertEqual(response.status_code, status.HTTP_200_OK)
     self.assertEqual(response.data, serializer.data)
     

--- a/back-end/api/quickstart/tests/endpoints/test_followers.py
+++ b/back-end/api/quickstart/tests/endpoints/test_followers.py
@@ -18,10 +18,10 @@ class GetFollow(TestCase):
   def test_get_valid_follow(self):
     response = client.get(f'/api/author/{self.receiver.id}/followers/{self.sender_id}/')
     serializer = FollowSerializer(self.follow)
-    print(response.data)
-    print(serializer.data)
+    
     self.assertEqual(response.status_code, status.HTTP_200_OK)
-    self.assertEqual(response.data, serializer.data)
+    for property in serializer.data.keys():
+      self.assertEqual(response.data[property], serializer.data[property])
     
 
   def test_get_invalid_follow(self):

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -206,13 +206,11 @@ class FollowersViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     def destroy(self, request, receiver, sender):
         try:
             author = Author.objects.get(id=receiver)
-            queryset = Follow.objects.filter(receiver=author, sender__id=sender)
-            if len(queryset) == 0:
-                return Response(status=status.HTTP_404_NOT_FOUND)
+            follow = Follow.objects.get(receiver=author, sender__id=sender)
 
-            queryset.first().delete()
+            follow.delete()
         
-        except Author.DoesNotExist:
+        except (Author.DoesNotExist, Follow.DoesNotExist):
             return Response(status=status.HTTP_404_NOT_FOUND)
             
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -184,13 +184,11 @@ class FollowersViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     def retrieve(self, request, receiver, sender):
         try:
             author = Author.objects.get(id=receiver)
-            queryset = Follow.objects.filter(receiver=author, sender__id=sender)
-            if len(queryset) == 0:
-                return Response(status=status.HTTP_404_NOT_FOUND)
+            follow = Follow.objects.get(receiver=author, sender__id=sender)
 
-            serializer = FollowSerializer(queryset.first())
+            serializer = FollowSerializer(follow)
 
-        except Author.DoesNotExist:
+        except (Author.DoesNotExist, Follow.DoesNotExist):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         return Response(serializer.data)


### PR DESCRIPTION
The GETing a follower test was failing due to the serializer JSON changes I had made previously. This test was failing because the order of properties on the response was not matching that of the serializer. I can take more time to look into it if we want but right now I don't see an issue with the properties not being in the same order and have changed the test to just make sure that all fields are correct. 

Added additional error checking on the view if the author searched for follows does not exist. 

Changed retrieve to be using get instead of filter when searching since there is only one author that should match.