### PR TITLE
Retrieve nodes on front-end upon login and registration

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -37,8 +37,8 @@ function App() {
     }
   },[loggedInUser])
 
-  // TODO wrap the below in NodesContext as well, and then send it into pages and use it 
-  // in the Axios wrapper. OR make Nodes global.
+  // TODO wrap the below in NodesContext as well, and then use the Nodes in other components.
+  // Talk to Chris about how to use React Context.
   return (
     <div>
       <LoggedInUserContext.Provider value={loggedInUser}>

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -27,6 +27,7 @@ function App() {
   const initialState:UserLogin|undefined = initialJSON ? JSON.parse(initialJSON) : undefined;
 
   const [loggedInUser,setLoggedInUser] = useState<UserLogin | undefined>(initialState);
+  const [nodes, setNodes] = useState<Node[]>([]);
 
   useEffect(()=>{
     if (loggedInUser === undefined){
@@ -36,16 +37,18 @@ function App() {
     }
   },[loggedInUser])
 
+  // TODO wrap the below in NodesContext as well, and then send it into pages and use it 
+  // in the Axios wrapper. OR make Nodes global.
   return (
     <div>
       <LoggedInUserContext.Provider value={loggedInUser}>
       <BrowserRouter>
         <div>
-          <AppNavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser}/>
+          <AppNavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser} />
           <Container fluid={true}>
             <Switch>
               <Route exact path="/" render={(props) => <HomePage {...props} loggedInUser={loggedInUser} />} />
-              <Route path="/auth" render={(props) => <AuthPage {...props} setLoggedInUser={setLoggedInUser} />} />
+              <Route path="/auth" render={(props) => <AuthPage {...props} setLoggedInUser={setLoggedInUser} setNodes={setNodes}/>} />
               <Route path="/author/:authorId" render={(props) => <AuthorPage {...props} loggedInUser={loggedInUser}/>}/>
               {/* TODO: hide settings page if not logged in */}
               <Route path="/settings" render={(props) => <SettingsPage loggedInUser={loggedInUser} />} />

--- a/front-end/src/components/LoginForm.jsx
+++ b/front-end/src/components/LoginForm.jsx
@@ -48,6 +48,12 @@ export default class LoginForm extends React.Component {
         this.setState({loginErr: true});
       });
 
+      axios.get(process.env.REACT_APP_API_URL + "/api/nodes/").then(res => {
+        this.props.setNodes(res.data);
+      }).catch(err => {
+        this.setState({loginErr: true});
+      });
+
     }).catch(err => {
       this.setState({loginErr: true});
     });

--- a/front-end/src/components/RegisterForm.jsx
+++ b/front-end/src/components/RegisterForm.jsx
@@ -40,6 +40,7 @@ export default class RegisterForm extends React.Component {
       password1: this.state.password,
       password2: this.state.passwordConf
     }).then(res => {
+
       axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`
       ).then(res => {
         this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: res.data.id});
@@ -47,6 +48,13 @@ export default class RegisterForm extends React.Component {
       }).catch(err => {
         this.setState({registerErr: err.response});
       });
+
+      axios.get(process.env.REACT_APP_API_URL + "/api/nodes/").then(res => {
+        this.props.setNodes(res.data);
+      }).catch(err => {
+        this.setState({loginErr: true});
+      });
+
     }).catch(err => {
       this.setState({registerErr: err.response});
     });

--- a/front-end/src/contexts/NodesContext.ts
+++ b/front-end/src/contexts/NodesContext.ts
@@ -1,0 +1,8 @@
+import React from "react";
+import { Node } from "../types/Node";
+
+/**
+ * Allows App to globally access the logged in user after login/registration. 
+ * App then sends UserLogin through props to child components.
+ */
+export const NodesContext = React.createContext<Node[]>([]);

--- a/front-end/src/pages/AuthPage.jsx
+++ b/front-end/src/pages/AuthPage.jsx
@@ -33,10 +33,10 @@ export default class AuthPage extends React.Component {
     let displayedForm = <h3>Form could not be found</h3>;
     switch (this.state.formType) {
       case "logIn":
-        displayedForm = <LoginForm setLoggedInUser={this.props.setLoggedInUser} history={this.props.history} changeForm={this.changeForm}/>
+        displayedForm = <LoginForm setLoggedInUser={this.props.setLoggedInUser} setNodes={this.props.setNodes} history={this.props.history} changeForm={this.changeForm}/>
         break;
       case "register":
-        displayedForm = <RegisterForm setLoggedInUser={this.props.setLoggedInUser} history={this.props.history} changeForm={this.changeForm}/>
+        displayedForm = <RegisterForm setLoggedInUser={this.props.setLoggedInUser} setNodes={this.props.setNodes} history={this.props.history} changeForm={this.changeForm}/>
         break;
       default:
         console.error("Unknown form type!");

--- a/front-end/src/types/Node.ts
+++ b/front-end/src/types/Node.ts
@@ -1,0 +1,5 @@
+export interface Node {
+  host: string
+  username: string;
+  password: string;
+}


### PR DESCRIPTION
Upon author login/registration, they will receive all nodes that are currently in our back-end.

The nodes still need to be used when making requests, but this can be done by me/Chris in a future PR. Will require making an axios wrapper. Also we have the decision of using this wrapper everywhere or only for the requests that we might make to external servers.