### PR TITLE
Keep track of Node for our own server upon login/registration

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -8,6 +8,7 @@ import NotFoundPage from './pages/NotFoundPage';
 import AuthPage from './pages/AuthPage';
 import { LoggedInUserContext } from './contexts/LoggedInUserContext';
 import { UserLogin } from './types/UserLogin';
+import { Node } from './types/Node';
 import AuthorPage from './pages/AuthorPage';
 import SettingsPage from './pages/SettingsPage';
 import CreatePostComponent from './components/CreatePost';
@@ -36,6 +37,15 @@ function App() {
     } else {
       localStorage.setItem(LOCAL_STORAGE_USER,JSON.stringify(loggedInUser));
     }
+
+    if (loggedInUser?.username !== undefined && loggedInUser?.password !== undefined) {
+      // Keep track of a Node representing our own server
+      setNodes(n => [...n, {
+        "host": process.env.REACT_APP_API_URL, // TODO may need to strip http:// from this host.
+        "username": loggedInUser?.username, 
+        "password": loggedInUser?.password
+      } as Node])
+    }
   },[loggedInUser])
 
   // TODO wrap the below in NodesContext as well, and then use the Nodes in other components.
@@ -45,7 +55,7 @@ function App() {
       <LoggedInUserContext.Provider value={loggedInUser}>
       <BrowserRouter>
         <div>
-          <AppNavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser} />
+          <AppNavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser} setNodes={setNodes} />
           <Container fluid={true}>
             <Switch>
               <Route exact path="/" render={(props) => <HomePage {...props} loggedInUser={loggedInUser} />} />

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -17,6 +17,7 @@ import PostDetailPage from './pages/PostDetailPage';
 import FollowersPage from './pages/FollowersPage';
 
 const LOCAL_STORAGE_USER = 'loggedInUser';
+const LOCAL_STORAGE_NODES = 'nodes';
 
 /*
 * Snippet based on
@@ -25,11 +26,13 @@ const LOCAL_STORAGE_USER = 'loggedInUser';
 */
 function App() {
   
-  const initialJSON = localStorage.getItem(LOCAL_STORAGE_USER);
-  const initialState:UserLogin|undefined = initialJSON ? JSON.parse(initialJSON) : undefined;
+  const initialUserJSON = localStorage.getItem(LOCAL_STORAGE_USER);
+  const initialUserState: UserLogin|undefined = initialUserJSON ? JSON.parse(initialUserJSON) : undefined;
+  const [loggedInUser,setLoggedInUser] = useState<UserLogin | undefined>(initialUserState);
 
-  const [loggedInUser,setLoggedInUser] = useState<UserLogin | undefined>(initialState);
-  const [nodes, setNodes] = useState<Node[]>([]);
+  const initialNodesJSON = localStorage.getItem(LOCAL_STORAGE_USER);
+  const initialNodesState: Node[] = initialNodesJSON ? JSON.parse(initialNodesJSON) : [];
+  const [nodes, setNodes] = useState<Node[]>(initialNodesState);
 
   useEffect(()=>{
     if (loggedInUser === undefined){
@@ -40,13 +43,25 @@ function App() {
 
     if (loggedInUser?.username !== undefined && loggedInUser?.password !== undefined) {
       // Keep track of a Node representing our own server
+
+      // Strip http:// or https:// from our own API URL
+      const host = process.env.REACT_APP_API_URL?.replace("http://", "").replace("https://", "");
+
       setNodes(n => [...n, {
-        "host": process.env.REACT_APP_API_URL, // TODO may need to strip http:// from this host.
+        "host": host,
         "username": loggedInUser?.username, 
         "password": loggedInUser?.password
       } as Node])
     }
   },[loggedInUser])
+
+  useEffect(() => {
+    if (nodes.length === 0){
+      localStorage.removeItem(LOCAL_STORAGE_NODES);
+    } else {
+      localStorage.setItem(LOCAL_STORAGE_NODES, JSON.stringify(nodes));
+    }
+  }, [nodes])
 
   // TODO wrap the below in NodesContext as well, and then use the Nodes in other components.
   // Talk to Chris about how to use React Context.

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   const initialUserState: UserLogin|undefined = initialUserJSON ? JSON.parse(initialUserJSON) : undefined;
   const [loggedInUser,setLoggedInUser] = useState<UserLogin | undefined>(initialUserState);
 
-  const initialNodesJSON = localStorage.getItem(LOCAL_STORAGE_USER);
+  const initialNodesJSON = localStorage.getItem(LOCAL_STORAGE_NODES);
   const initialNodesState: Node[] = initialNodesJSON ? JSON.parse(initialNodesJSON) : [];
   const [nodes, setNodes] = useState<Node[]>(initialNodesState);
 
@@ -39,21 +39,23 @@ function App() {
       localStorage.removeItem(LOCAL_STORAGE_USER);
     } else {
       localStorage.setItem(LOCAL_STORAGE_USER,JSON.stringify(loggedInUser));
-    }
 
-    if (loggedInUser?.username !== undefined && loggedInUser?.password !== undefined) {
-      // Keep track of a Node representing our own server
+      // Already have a Node for our own server.
+      if (nodes.filter(n => n.username === loggedInUser.username).length !== 0) {
+        return;
+      }
 
       // Strip http:// or https:// from our own API URL
       const host = process.env.REACT_APP_API_URL?.replace("http://", "").replace("https://", "");
 
-      setNodes(n => [...n, {
+      // Keep track of a Node representing our own server
+      setNodes([...nodes, {
         "host": host,
         "username": loggedInUser?.username, 
         "password": loggedInUser?.password
       } as Node])
     }
-  },[loggedInUser])
+  },[loggedInUser, nodes])
 
   useEffect(() => {
     if (nodes.length === 0){

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -58,6 +58,8 @@ function App() {
   },[loggedInUser, nodes])
 
   useEffect(() => {
+    console.log("Nodes: ");
+    console.log(nodes);
     if (nodes.length === 0){
       localStorage.removeItem(LOCAL_STORAGE_NODES);
     } else {

--- a/front-end/src/components/AppNavBar.tsx
+++ b/front-end/src/components/AppNavBar.tsx
@@ -8,11 +8,13 @@ import {
 } from "reactstrap";
 import { NavLink } from "react-router-dom";
 import { UserLogin } from "../types/UserLogin";
+import { Node } from "../types/Node";
 import FriendRequestListModal from "./FriendRequestListModal";
 
 interface Props {
   loggedInUser: UserLogin | undefined;
   setLoggedInUser: React.Dispatch<React.SetStateAction<UserLogin | undefined>>;
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
 }
 
 /**
@@ -31,7 +33,10 @@ export default function AppNavBar(props: Props) {
 
   const toggle = () => setIsOpen(!isOpen);
   const close = () => setIsOpen(false);
-  const logOut = () => props.setLoggedInUser(undefined);
+  const logOut = () => {
+    props.setLoggedInUser(undefined);
+    props.setNodes([])
+  }
 
   // display pages accessible to a logged in author
   function loggedIn() {

--- a/front-end/src/components/LoginForm.jsx
+++ b/front-end/src/components/LoginForm.jsx
@@ -36,26 +36,16 @@ export default class LoginForm extends React.Component {
     axios.post(process.env.REACT_APP_API_URL + "/api/rest-auth/login/", {
       username: this.state.username,
       password: this.state.password
-    }).then(res => {
-      //Store token in a cookie
-      // document.cookie = "accessToken=" + res.data.key;
-
-      axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`
-      ).then(res => {
-        this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: res.data.id});
-        this.props.history.push("/");
-      }).catch(err => {
-        this.setState({loginErr: true});
-      });
-
-      axios.get(process.env.REACT_APP_API_URL + "/api/nodes/").then(res => {
-        this.props.setNodes(res.data);
-      }).catch(err => {
-        this.setState({loginErr: true});
-      });
-
+    }).then(_ => {
+      return axios.get(process.env.REACT_APP_API_URL + "/api/nodes/");
+    }).then(nodes => {
+      this.props.setNodes(nodes.data);
+      return axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
+    }).then(user => {
+      this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id});
+      this.props.history.push("/");
     }).catch(err => {
-      this.setState({loginErr: true});
+      this.setState({loginErr: err.response});
     });
     e.preventDefault();
   }

--- a/front-end/src/components/RegisterForm.jsx
+++ b/front-end/src/components/RegisterForm.jsx
@@ -39,22 +39,14 @@ export default class RegisterForm extends React.Component {
       username: this.state.username,
       password1: this.state.password,
       password2: this.state.passwordConf
-    }).then(res => {
-
-      axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`
-      ).then(res => {
-        this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: res.data.id});
-        this.props.history.push("/");
-      }).catch(err => {
-        this.setState({registerErr: err.response});
-      });
-
-      axios.get(process.env.REACT_APP_API_URL + "/api/nodes/").then(res => {
-        this.props.setNodes(res.data);
-      }).catch(err => {
-        this.setState({loginErr: true});
-      });
-
+    }).then(_ => {
+      return axios.get(process.env.REACT_APP_API_URL + "/api/nodes/");
+    }).then(nodes => {
+      this.props.setNodes(nodes.data);
+      return axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
+    }).then(user => {
+      this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id});
+      this.props.history.push("/");
     }).catch(err => {
       this.setState({registerErr: err.response});
     });

--- a/front-end/src/pages/AuthorResultsPage.tsx
+++ b/front-end/src/pages/AuthorResultsPage.tsx
@@ -21,6 +21,7 @@ export default function AuthorResultsPage(props:any) {
 
   // get all authors and filter through to find the one we're searching for
   useEffect(() => {
+    // TODO - will need to make requests to all 3 servers.
     axios.get(`${process.env.REACT_APP_API_URL}/api/authors/`)
     .then(response => {
         const filteredAuthorsResponse = response.data.filter((author:Author) => author.displayName === displayName);


### PR DESCRIPTION
I've serialized the requests on Login/Registration (and also removed many redundant `.catch` expressions on Promises) so that it goes
POST login/register ->
GET nodes ->
GET authuser

When GET authuser succeeds, I've added code into its useEffect to add a Node for our own server into the Nodes list. Then the axios wrapper we create can properly make requests to our own server as well.

EDIT: I've also added code to save these nodes to local storage so they aren't lost on refresh. Uses the same mechanism as UserLogin does.

Here's what Node objects look like.
![image](https://user-images.githubusercontent.com/11599574/112398327-90c3d380-8cc9-11eb-890d-c32d9b1db196.png)
