### PR TITLE
Create Axios wrapper

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -50,9 +50,9 @@ function App() {
 
       // Keep track of a Node representing our own server
       setNodes([...nodes, {
-        "host": host,
-        "username": loggedInUser?.username, 
-        "password": loggedInUser?.password
+        host: host,
+        username: loggedInUser?.username, 
+        password: loggedInUser?.password
       } as Node])
     }
   },[loggedInUser, nodes])

--- a/front-end/src/helpers/AxiosWrapper.tsx
+++ b/front-end/src/helpers/AxiosWrapper.tsx
@@ -1,0 +1,47 @@
+import { Node } from '../types/Node';
+import axios, { AxiosResponse } from 'axios';
+
+interface Credentials {
+  username: string;
+  password: string;
+}
+
+class AxiosWrapper {
+  nodes: Node[]
+
+  constructor(nodes: Node[]) {
+    this.nodes = nodes;
+  }
+  
+  /**
+   * Given a URL, checks the host and retrieves the credentials requests to that URL should be made with.
+   * @param url to get the credentials for
+   */
+  private getCredentialsForUrl(url: string) {
+    let nodes = this.nodes.filter(n => n.host.includes(url));
+
+    let credentials: Credentials = nodes.length === 0 
+      ? { username: "", password: "" }
+      : { username: nodes[0].username, password: nodes[0].password };
+    
+    return {
+      auth: credentials
+    };
+  }
+
+  get(url: string): Promise<AxiosResponse<any>> {
+    return axios.get(url, this.getCredentialsForUrl(url));
+  }
+
+  delete(url: string): Promise<AxiosResponse<any>> {
+    return axios.delete(url, this.getCredentialsForUrl(url));
+  }
+
+  post(url: string, data: any): Promise<AxiosResponse<any>> {
+    return axios.post(url, data, this.getCredentialsForUrl(url));
+  }
+
+  put(url: string, data: any): Promise<AxiosResponse<any>> {
+    return axios.put(url, data, this.getCredentialsForUrl(url));
+  }
+}


### PR DESCRIPTION
Created an Axios wrapper that should replace `axios` to make API requests whenever we use an endpoint that could be cross-server.

TODO: Still needs to be actually constructed and used instead of axios.

Closing PR in favour of #167