### PR TITLE
Setup sending created posts to followers inbox

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -25,6 +25,7 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
+    "startdev": "react-scripts start",
     "start": "REACT_APP_API_URL=http://localhost:8000 react-scripts start",
     "build": "REACT_APP_API_URL=https://cyver.herokuapp.com react-scripts build",
     "test": "react-scripts test",

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { Alert, Form, FormGroup, Input, Label, Modal, ModalBody, ModalFooter, ModalHeader } from "reactstrap";
 import { Post, PostContent, PostContentType, PostVisibility } from "../types/Post";
 import { UserLogin } from "../types/UserLogin";
+import { Author } from "../types/Author";
 import PostContentEl from "./PostContentEl";
 
 interface Props {
@@ -103,8 +104,17 @@ export default function CreateEditPostModal(props: Props){
 
       if(isCreate){
         axios.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/", data, config)
-          .then(res => {
-            handleRes(res)
+          .then(post => {
+            handleRes(post)
+            return post
+          }).then(post => {
+            // send this post to all followers
+            axios.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/followers/`).then(res => {
+              let followingList: Author[] = res.data.items;
+              followingList.forEach(follower => {
+                axios.post(`${process.env.REACT_APP_API_URL}/api/author/${follower.id}/inbox/`, post.data);
+              });
+            });
           }).catch(error => {
             setShowError(true)
           })

--- a/front-end/src/components/FriendRequestButton.tsx
+++ b/front-end/src/components/FriendRequestButton.tsx
@@ -12,9 +12,8 @@ interface Props {
 
 export default function FollowRequestButton(props: Props) {
   // TODO: change this to use currentAuthor.url
-  const authorUrl = process.env.REACT_APP_API_URL + "/api/author/" + props.currentAuthor?.id + "/followers/" + props.loggedInUser?.authorId + "/";
-  const inboxUrl = process.env.REACT_APP_API_URL + "/api/author/" + props.currentAuthor?.id + "/inbox/";
-  const loggedInUserUrl = process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser?.authorId;
+  const authorUrl = `${process.env.REACT_APP_API_URL}/api/author/${props.currentAuthor?.id}/followers/${props.loggedInUser?.authorId}/`;
+  const loggedInUserUrl = `${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser?.authorId}/`;
 
   const sendFollowRequest = () => {
     // TODO: add authentication


### PR DESCRIPTION
When a post is created, the front end will now get all the followers of the user and send the post to each of their inboxes. Also setup a script to run the frontend locally without the  REACT_APP_API_URL environment variable.

user abc4's inbox shows abc3's post, since abc4 is following abc3
![image](https://user-images.githubusercontent.com/36487188/112413883-a1cf0d80-8ce6-11eb-8e34-ee62bd08085e.png)

Also fixed followbutton urls to have the trailing slash and use format strings