### PR TITLE
GET authors from all possible servers when searching

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -42,16 +42,13 @@ function App() {
       localStorage.setItem(LOCAL_STORAGE_USER,JSON.stringify(loggedInUser));
 
       // Already have a Node for our own server.
-      if (nodes.filter(n => n.username === loggedInUser.username).length !== 0) {
+      if (nodes.filter(n => n.host === process.env.REACT_APP_API_URL).length !== 0) {
         return;
       }
 
-      // Strip http:// or https:// from our own API URL
-      const host = process.env.REACT_APP_API_URL?.replace("http://", "").replace("https://", "");
-
       // Keep track of a Node representing our own server
       setNodes([...nodes, {
-        host: host,
+        host: process.env.REACT_APP_API_URL,
         username: loggedInUser?.username, 
         password: loggedInUser?.password
       } as Node])
@@ -87,7 +84,7 @@ function App() {
               {/* TODO: hide settings page if not logged in */}
               <Route path="/settings" render={() => <SettingsPage loggedInUser={loggedInUser} />} />
               <Route path="/create_post" render={(props) => <CreatePostComponent {...props} loggedInUser={loggedInUser} />} />
-              <Route path="/authors/:displayName" render={(props) => <AuthorResultsPage {...props} loggedInUser={loggedInUser}/>}/>
+              <Route path="/authors/:displayName" render={(props) => <AuthorResultsPage {...props} loggedInUser={loggedInUser} nodes={nodes} />}/>
               <Route path="/posts/:postId" render={(props) => <PostDetailPage {...props} loggedInUser={loggedInUser}/>}/>
               <Route component={NotFoundPage} />
             </Switch>

--- a/front-end/src/pages/AuthorResultsPage.tsx
+++ b/front-end/src/pages/AuthorResultsPage.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps, useParams } from 'react-router-dom';
 import { Row, Col } from 'reactstrap';
 import AuthorList from "../components/AuthorList"
 import { Author } from '../types/Author';
+import { Node } from '../types/Node';
 
 /**
  * Render list of search results when searching for an author by display name
@@ -21,11 +22,13 @@ export default function AuthorResultsPage(props:any) {
 
   // get all authors and filter through to find the one we're searching for
   useEffect(() => {
-    // TODO - will need to make requests to all 3 servers. Use Promises.all?
-    AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/authors/`)
-    .then((res: any) => {
-        const filteredAuthorsResponse = res.data.filter((author:Author) => author.displayName === displayName);
-        setAuthors(filteredAuthorsResponse);
+    // NOTE: Search functionality does not work for users that are not logged in. (they have no Node credentials).
+    let requests = AxiosWrapper.nodes.map((n: Node) => {
+      return AxiosWrapper.get(`${n.host}/api/authors/`);
+    })
+
+    Promise.all(requests).then((authors: any) => {
+      setAuthors(authors.data.filter((a: Author) => a.displayName === displayName));
     })
   }, []);
 

--- a/front-end/src/pages/AuthorResultsPage.tsx
+++ b/front-end/src/pages/AuthorResultsPage.tsx
@@ -23,12 +23,15 @@ export default function AuthorResultsPage(props:any) {
   // get all authors and filter through to find the one we're searching for
   useEffect(() => {
     // NOTE: Search functionality does not work for users that are not logged in. (they have no Node credentials).
-    let requests = AxiosWrapper.nodes.map((n: Node) => {
-      return AxiosWrapper.get(`${n.host}/api/authors/`);
+    let requests = props.nodes.map((n: Node) => {
+      const url = `${n.host}/api/authors/`
+      console.log(`Getting authors from ${url}`);
+      return AxiosWrapper.get(url);
     })
 
-    Promise.all(requests).then((authors: any) => {
-      setAuthors(authors.data.filter((a: Author) => a.displayName === displayName));
+    Promise.allSettled(requests).then((results: any) => {
+      let authors = results.filter((r: any) => r.status === "fulfilled").map((r: any) => r.value.data).flat(); 
+      setAuthors(authors.filter((a: Author) => a.displayName === displayName));
     })
   }, []);
 


### PR DESCRIPTION
I loop through the array of Nodes we have and make a request to each of their /api/authors/ endpoints, and collect the result using `Promises.allSettled`.

I then get the authors out of all Promises that resolved successfully (fulfilled) and display that.
Other endpoints we're making requests to still need to be generalized for across cross-server (follow, inbox/like)