### PR TITLE
Implemented a friends list endpoint

### DIFF
--- a/back-end/api/api/urls.py
+++ b/back-end/api/api/urls.py
@@ -76,6 +76,12 @@ comments = views.CommentViewSet.as_view({
     'post': 'create'
 })
 
+# Endpoint: /api/author/{AUTHOR_ID}/friends/
+# GET: get a list of authors who they are friends with
+friends_list = views.FriendsListViewSet.as_view({
+    'get': 'list'
+})
+
 # Endpoint: /api/author/{AUTHOR_ID}/followers
 # GET: get a list of authors who are their followers
 followers_list = views.FollowersListViewSet.as_view({
@@ -153,6 +159,7 @@ urlpatterns = [
     path('api/nodes/', nodes, name='nodes'),
     path('api/author/<str:author>/posts/', posts_list, name='posts-list'),
     path('api/author/<str:author>/posts/<str:id>/', posts, name='posts'),
+    path('api/author/<str:author>/friends/', friends_list, name='friends-list'),
     path('api/author/<str:receiver>/followers/', followers_list, name='followers-list'),
     path('api/author/<str:receiver>/followers/<str:sender>/', followers, name='followers'),
     path('api/author/<str:sender>/following/', following_list, name='following-list'),

--- a/back-end/api/quickstart/tests/endpoints/test_friends_list.py
+++ b/back-end/api/quickstart/tests/endpoints/test_friends_list.py
@@ -24,16 +24,12 @@ class GetFriends(TestCase):
     self.follows = [
       Follow.objects.create(receiver=self.author, sender=AuthorSerializer(self.friends[0]).data),
       Follow.objects.create(receiver=self.author, sender=AuthorSerializer(self.friends[1]).data),
-      Follow.objects.create(receiver=self.friends[0], sender=AuthorSerializer(self.author).data),
-      Follow.objects.create(receiver=self.friends[1], sender=AuthorSerializer(self.author).data),
       Follow.objects.create(receiver=self.author, sender=AuthorSerializer(self.other_follower).data),
     ]
 
     self.followings = [
       Following.objects.create(receiver=AuthorSerializer(self.friends[0]).data, sender=self.author),
       Following.objects.create(receiver=AuthorSerializer(self.friends[1]).data, sender=self.author),
-      Following.objects.create(receiver=AuthorSerializer(self.author).data, sender=self.friends[0]),
-      Following.objects.create(receiver=AuthorSerializer(self.author).data, sender=self.friends[1]),
       Following.objects.create(receiver=AuthorSerializer(self.other_followings).data, sender=self.author),
     ]
 

--- a/back-end/api/quickstart/tests/endpoints/test_friends_list.py
+++ b/back-end/api/quickstart/tests/endpoints/test_friends_list.py
@@ -1,0 +1,51 @@
+import json
+from rest_framework import status
+from django.test import TestCase, Client
+from quickstart.models import Author, Follow, Following
+from quickstart.serializers import AuthorSerializer
+from quickstart.tests.helper_test import get_test_author_fields, get_follow_author_fields
+
+client = Client()
+
+class GetFriends(TestCase):
+  """Tests for getting all friends of an author at endpoint /api/author/{author}/friends/."""
+  def setUp(self):
+    self.author = Author.objects.create(**get_test_author_fields(i=1))
+
+    self.friends = [
+      Author.objects.create(**get_test_author_fields(i=2)), 
+      Author.objects.create(**get_test_author_fields(i=3))
+    ]
+
+    self.other_follower = Author.objects.create(**get_test_author_fields(i=4))
+    
+    self.other_followings = Author.objects.create(**get_test_author_fields(i=5))
+
+    self.follows = [
+      Follow.objects.create(receiver=self.author, sender=AuthorSerializer(self.friends[0]).data),
+      Follow.objects.create(receiver=self.author, sender=AuthorSerializer(self.friends[1]).data),
+      Follow.objects.create(receiver=self.friends[0], sender=AuthorSerializer(self.author).data),
+      Follow.objects.create(receiver=self.friends[1], sender=AuthorSerializer(self.author).data),
+      Follow.objects.create(receiver=self.author, sender=AuthorSerializer(self.other_follower).data),
+    ]
+
+    self.followings = [
+      Following.objects.create(receiver=AuthorSerializer(self.friends[0]).data, sender=self.author),
+      Following.objects.create(receiver=AuthorSerializer(self.friends[1]).data, sender=self.author),
+      Following.objects.create(receiver=AuthorSerializer(self.author).data, sender=self.friends[0]),
+      Following.objects.create(receiver=AuthorSerializer(self.author).data, sender=self.friends[1]),
+      Following.objects.create(receiver=AuthorSerializer(self.other_followings).data, sender=self.author),
+    ]
+
+    self.friends_obj = [
+      AuthorSerializer(self.friends[0]).data,
+      AuthorSerializer(self.friends[1]).data
+    ] 
+
+  def test_get_all_friends(self):
+    response = client.get(f'/api/author/{self.author.id}/friends/')
+
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(response.data['type'], 'friends')
+    print(response.data["items"])
+    self.assertEqual(response.data['items'], self.friends_obj)

--- a/back-end/api/quickstart/tests/endpoints/test_friends_list.py
+++ b/back-end/api/quickstart/tests/endpoints/test_friends_list.py
@@ -47,5 +47,4 @@ class GetFriends(TestCase):
 
     self.assertEqual(response.status_code, status.HTTP_200_OK)
     self.assertEqual(response.data['type'], 'friends')
-    print(response.data["items"])
     self.assertEqual(response.data['items'], self.friends_obj)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -182,6 +182,7 @@ class FriendsListViewSet(viewsets.ModelViewSet):
                 for following in following_queryset:
                     if follow.sender["id"] == following.receiver["id"]:
                         friends.append(follow.sender)
+                        break
 
         except Author.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -167,6 +167,31 @@ class CommentViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
+class FriendsListViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows for listing the friends of an author.
+    """
+    def list(self, request, author):
+        try:
+            author = Author.objects.get(id=author)
+            follow_queryset = Follow.objects.filter(receiver=author)
+            following_queryset = Following.objects.filter(sender=author)
+
+            friends = []
+            for follow in follow_queryset:
+                for following in following_queryset:
+                    if follow.sender["id"] == following.receiver["id"]:
+                        friends.append(follow.sender)
+
+        except Author.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+            
+        return Response({
+            'type': 'friends',
+            'items': friends
+        })
+
+
 class FollowersListViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows for listing the followers of an author.


### PR DESCRIPTION
Sending a GET to /api/author/AUTHOR_ID/friends/ will return a list of all friends for that author. Gets all friends by finding the intersection between the followers of the author and who the author is following.

An example response when GETing to this endpoint:
```
[
  {
    'id': 'd9e76209-52e4-4fc1-b781-52daba14d342', 
    'url': 'testUrl2', 
    'host': 'testHost', 
    'type': 'author', 
    'github': 'testGithub2', 
    'displayName': 'John Doe 2'
  }, 
  {
    'id': '9e3944f0-2d96-47d9-b6a7-4f9d5a1e2a82', 
    'url': 'testUrl3', 
    'host': 'testHost', 
    'type': 'author', 
    'github': 'testGithub3', 
    'displayName': 'John Doe 3'
  }
]
```