### PR TITLE
Change request URLs to support cross-server actions

### DIFF
--- a/front-end/src/components/AuthorListItem.tsx
+++ b/front-end/src/components/AuthorListItem.tsx
@@ -16,8 +16,7 @@ interface Props {
  * @param props 
  */
 export default function AuthorListItem(props: Props) {
-  // TODO: this will eventually change to be using the host from the author when we start connecting with other groups
-  const isFollowerUrl = process.env.REACT_APP_API_URL + "/api/author/" + props.author.id + "/followers/" + props.loggedInUser?.authorId;
+  const isFollowerUrl = `${props.author.host}api/author/${props.author.id}/followers/${props.loggedInUser?.authorId}`;
 
   const [isFollower, setIsFollower] = useState<boolean>(false);
 

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -107,7 +107,7 @@ export default function CreateEditPostModal(props: Props){
             AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/followers/`).then((res: any) => {
               let followingList: Author[] = res.data.items;
               followingList.forEach(follower => {
-                AxiosWrapper.post(`${process.env.REACT_APP_API_URL}/api/author/${follower.id}/inbox/`, post.data);
+                AxiosWrapper.post(`${follower.host}api/author/${follower.id}/inbox/`, post.data);
               });
             });
           }).catch((error: any) => {

--- a/front-end/src/components/FriendRequestButton.tsx
+++ b/front-end/src/components/FriendRequestButton.tsx
@@ -11,12 +11,11 @@ interface Props {
 }
 
 export default function FollowRequestButton(props: Props) {
-  const authorUrl = `${process.env.REACT_APP_API_URL}/api/author/${props.currentAuthor?.id}/followers/${props.loggedInUser?.authorId}/`;
+  const authorUrl = `${props.currentAuthor?.host}api/author/${props.currentAuthor?.id}/followers/${props.loggedInUser?.authorId}/`;
   const loggedInUserUrl = `${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser?.authorId}/`;
   const followingUrl = `${loggedInUserUrl}following/${props.currentAuthor?.id}/`;
 
   const sendFollowRequest = () => {
-    // TODO: add authentication
     // get the loggedinuser author object
     AxiosWrapper.get(loggedInUserUrl).then((res: any) => {
       if (!props.isFollower) {

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -57,7 +57,7 @@ export default function PostListItem(props: Props) {
           object: `${process.env.REACT_APP_API_URL}/api/author/${props.post.author.id}/posts/${props.post.id}`
         }
 
-        return AxiosWrapper.post(`${process.env.REACT_APP_API_URL}/api/author/${props.post.author.id}/inbox/`,
+        return AxiosWrapper.post(`${props.post.author.host}api/author/${props.post.author.id}/inbox/`,
           like
         )
       }).then((res: any) => {


### PR DESCRIPTION
Instead of always prepending our API endpoint environment variable to request URLs, we look at Author objects' host fields and prepend that to our requests.

This is now being done for: sending likes to Inbox, sending posts to Inbox, following an Author, and checking if we are already following an Author.

Note that our environment variable has no trailing slash, but `author.host` does have trailing slashes, so there is a bit of mismatch in the URLs we make requests to: author.host + "api/author" as opposed to envvar + "/api/author"