### PR TITLE
Private post are now only sent to friends inboxes

### DIFF
--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -103,13 +103,23 @@ export default function CreateEditPostModal(props: Props){
             handleRes(post)
             return post
           }).then((post: any) => {
-            // send this post to all followers
-            AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/followers/`).then((res: any) => {
-              let followingList: Author[] = res.data.items;
-              followingList.forEach(follower => {
-                AxiosWrapper.post(`${process.env.REACT_APP_API_URL}/api/author/${follower.id}/inbox/`, post.data);
+            if (visibility === PostVisibility.FRIENDS) {
+              // send this post to friends only
+              AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/friends/`).then((res: any) => {
+                let friendsList: Author[] = res.data.items;
+                friendsList.forEach(friend => {
+                  AxiosWrapper.post(`${process.env.REACT_APP_API_URL}/api/author/${friend.id}/inbox/`, post.data);
+                });
+              })
+            } else {
+              // send this post to all followers (which are friends and followers)
+              AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/followers/`).then((res: any) => {
+                let followingList: Author[] = res.data.items;
+                followingList.forEach(follower => {
+                  AxiosWrapper.post(`${process.env.REACT_APP_API_URL}/api/author/${follower.id}/inbox/`, post.data);
+                });
               });
-            });
+            }
           }).catch((error: any) => {
             setShowError(true)
           })


### PR DESCRIPTION
Private post are now sent only to friends by GETing all the friends and posting to each of their inboxes.

Author abc3 is following abc2 but abc2 is not following back. Therefore abc3's inbox is empty when abc2 made a private post.
![image](https://user-images.githubusercontent.com/36487188/112566464-a6f29200-8da4-11eb-96f6-c7c2a7b96afc.png)

Author abc1 is following abc2 and vice versa, therefore they are friends. abc1 now sees the private post that abc2 made.
![image](https://user-images.githubusercontent.com/36487188/112566557-d4d7d680-8da4-11eb-9a90-804b5ef36ea3.png)
