### PR TITLE
Auth endpoints that we use cross-server

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_authors.py
+++ b/back-end/api/quickstart/tests/endpoints/test_authors.py
@@ -1,13 +1,19 @@
 from rest_framework import status
-from django.test import TestCase, Client
+from rest_framework.test import APIClient, force_authenticate
+from django.contrib.auth.models import User
+from django.test import TestCase
 from quickstart.models import Author
 from quickstart.serializers import AuthorSerializer
 from quickstart.tests.helper_test import get_test_author_fields
 
-client = Client()
+client = APIClient()
 
 class GetAuthorById(TestCase):
   """Tests for getting all Authors at endpoint /api/authors/."""
+
+  def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
+
   def test_get_authors(self):
     for i in range(3):
       Author.objects.create(**get_test_author_fields())

--- a/back-end/api/quickstart/tests/endpoints/test_comment.py
+++ b/back-end/api/quickstart/tests/endpoints/test_comment.py
@@ -1,15 +1,18 @@
 import json
 from rest_framework import status
-from django.test import TestCase, Client
+from rest_framework.test import APIClient, force_authenticate
+from django.contrib.auth.models import User
+from django.test import TestCase
 from quickstart.models import Comment
 from quickstart.serializers import CommentSerializer
 from quickstart.tests.helper_test import get_test_comment_fields
 
-client = Client()
+client = APIClient()
 
 class GetAllCommentsTest(TestCase):
   """Tests for getting all comments of a given post at endpoint /api/author/<str:author>/posts/<str:post>/comments/"""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.test_post_id = 1
     self.test_other_post_id = 2
     self.comment1 = Comment.objects.create(**get_test_comment_fields(1), postId=self.test_post_id)
@@ -44,6 +47,7 @@ class CreateCommentTest(TestCase):
   """
 
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.payload = get_test_comment_fields(1)
 
   def test_create_comment(self):

--- a/back-end/api/quickstart/tests/endpoints/test_followers.py
+++ b/back-end/api/quickstart/tests/endpoints/test_followers.py
@@ -1,15 +1,18 @@
 import json
 from rest_framework import status
+from rest_framework.test import APIClient, force_authenticate
+from django.contrib.auth.models import User
 from django.test import TestCase, Client
 from quickstart.models import Follow, Author, Inbox
 from quickstart.serializers import FollowSerializer, AuthorSerializer
 from quickstart.tests.helper_test import get_follow_author_fields, get_test_author_fields
 
-client = Client()
+client = APIClient()
 
 class GetFollow(TestCase):
   """Tests for getting a single Follow at endpoint /api/author/{RECEIVER_ID}/followers/{SENDER_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.receiver = Author.objects.create(**get_test_author_fields())
     self.sender = Author.objects.create(**get_test_author_fields())
     self.sender_id = self.sender.id
@@ -32,6 +35,7 @@ class GetFollow(TestCase):
 class DeleteFollow(TestCase):
   """Tests for deleting a single Follow at endpoint /api/author/{RECEIVER_ID}/followers/{SENDER_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.receiver = Author.objects.create(**get_test_author_fields())
     self.sender = Author.objects.create(**get_test_author_fields())
     self.sender_id = self.sender.id
@@ -49,6 +53,7 @@ class DeleteFollow(TestCase):
 class CreateFollow(TestCase):
   """Tests for creating a Follow by PUT'ing to endpoint /api/author/{RECEIVER_ID}/followers/{SENDER_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.receiver = Author.objects.create(**get_test_author_fields(i=1))
     self.inbox = Inbox.objects.create(author=self.receiver)
     self.sender = get_follow_author_fields()

--- a/back-end/api/quickstart/tests/endpoints/test_following.py
+++ b/back-end/api/quickstart/tests/endpoints/test_following.py
@@ -1,15 +1,18 @@
 import json
 from rest_framework import status
-from django.test import TestCase, Client
+from rest_framework.test import APIClient, force_authenticate
+from django.contrib.auth.models import User
+from django.test import TestCase
 from quickstart.models import Following, Author
 from quickstart.serializers import FollowingSerializer, AuthorSerializer
 from quickstart.tests.helper_test import get_follow_author_fields, get_test_author_fields
 
-client = Client()
+client = APIClient()
 
 class GetFollowing(TestCase):
   """Tests for getting a single Following at endpoint /api/author/{SENDER_ID}/following/{RECEIVER_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.receiver = Author.objects.create(**get_test_author_fields())
     self.sender = Author.objects.create(**get_test_author_fields())
     self.following = Following.objects.create(receiver=AuthorSerializer(self.receiver).data, sender=self.sender)
@@ -31,6 +34,7 @@ class GetFollowing(TestCase):
 class DeleteFollowing(TestCase):
   """Tests for deleting a single Following at endpoint /api/author/{SENDER_ID}/following/{RECEIVER_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.receiver = Author.objects.create(**get_test_author_fields())
     self.sender = Author.objects.create(**get_test_author_fields())
     self.follow = Following.objects.create(receiver=AuthorSerializer(self.receiver).data, sender=self.sender)
@@ -47,6 +51,7 @@ class DeleteFollowing(TestCase):
 class CreateFollowing(TestCase):
   """Tests for creating a Following by PUT'ing to endpoint /api/author/{SENDER_ID}/following/{RECEIVER_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.sender = Author.objects.create(**get_test_author_fields(i=1))
     self.receiver = get_follow_author_fields()
     self.receiver_id = self.receiver["id"]

--- a/back-end/api/quickstart/tests/endpoints/test_inbox.py
+++ b/back-end/api/quickstart/tests/endpoints/test_inbox.py
@@ -1,16 +1,19 @@
 import json
 import uuid
 from rest_framework import status
-from django.test import TestCase, Client
+from rest_framework.test import APIClient, force_authenticate
+from django.contrib.auth.models import User
+from django.test import TestCase
 from quickstart.models import Like, Inbox, Author
 from quickstart.serializers import InboxSerializer
 from quickstart.tests.helper_test import get_test_post_fields, get_follow_author_fields, get_test_like_fields, get_test_author_fields
 
-client = Client()
+client = APIClient()
 
 class GetInbox(TestCase):
   """Tests to GET an author's inbox at endpoint /api/author/<str:author>/inbox/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.inbox = Inbox.objects.create(author=Author.objects.create(**get_test_author_fields()))
     self.inbox.items.append(get_test_post_fields())
     self.inbox.items.append(get_follow_author_fields())
@@ -32,6 +35,7 @@ class GetInbox(TestCase):
 class PostInbox(TestCase):
   """Tests for sending a post/follow/like to an inbox by POST'ing to /api/author/<str:author>/inbox/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.inbox = Inbox.objects.create(author=Author.objects.create(**get_test_author_fields()))
 
   def test_send_post_to_inbox(self):
@@ -69,6 +73,7 @@ class PostInbox(TestCase):
 class ClearInbox(TestCase):
   """Tests for clearing an author's inbox by DELETE'ing to /api/author/<str:author>/inbox/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.inbox = Inbox.objects.create(author=Author.objects.create(**get_test_author_fields()))
     self.inbox.items.append(get_follow_author_fields())
     self.inbox.save()

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -29,6 +29,8 @@ class AuthorsViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows getting all authors.
     """
+    authentication_classes = [BasicAuthentication]
+    permission_classes = [IsAuthenticated]
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
     lookup_field = 'id'
@@ -191,6 +193,8 @@ class FollowersViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     """
     API endpoint that allows removing, adding, and checking followers for an author.
     """
+    authentication_classes = [BasicAuthentication]
+    permission_classes = [IsAuthenticated]
     queryset = Follow.objects.all()
     serializer_class = FollowSerializer
     lookup_fields = ['receiver']
@@ -264,6 +268,8 @@ class FollowingViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows removing, adding, and checking other authors an author is following.
     """
+    authentication_classes = [BasicAuthentication]
+    permission_classes = [IsAuthenticated]
     queryset = Following.objects.all()
     serializer_class = FollowingSerializer
 
@@ -358,6 +364,8 @@ class InboxViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows getting inbox items for an author
     """
+    authentication_classes = [BasicAuthentication]
+    permission_classes = [IsAuthenticated]
     queryset = Inbox.objects.all()
     serializer_class = InboxSerializer
     lookup_field = 'author'

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -155,6 +155,8 @@ class CommentViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows comments to be viewed or edited.
     """
+    authentication_classes = [BasicAuthentication]
+    permission_classes = [IsAuthenticated]
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
     lookup_field = 'id'

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -36,7 +36,7 @@ export default function PostListItem(props: Props) {
   const toggleDelete = () => setIsDeleteModalOpen(!isDeleteModalOpen);
 
   useEffect(() => {
-    AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${post.author.id}/posts/${post.id}/likes/`).then((res: any) => {
+    AxiosWrapper.get(`${post.author.host}api/author/${post.author.id}/posts/${post.id}/likes/`).then((res: any) => {
       const resLikes: Like[] = res.data.items;
       setLikes(resLikes);
       setHasLiked(resLikes.filter((l: Like) => l.author.id === props.loggedInUser?.authorId).length !== 0);


### PR DESCRIPTION
To properly ensure that these endpoints only work when authenticated, I've added that they require BasicAuth in the back-end.

Note that we're trying to target:

GET all authors
POST like/ POST post to an inbox
GET/POST follower for an author
POST comments

Note that we can only put auth classes on a whole ViewSet and not specific methods of a ViewSet. If we can figure out how to do it on specific methods of a ViewSet, let me know. (All methods endpoint provides will require auth because of this).