### PR TITLE
Add trailing slash to inbox URL

### DIFF
--- a/front-end/src/components/FriendRequestListModal.tsx
+++ b/front-end/src/components/FriendRequestListModal.tsx
@@ -9,7 +9,7 @@ const FriendRequestListModal = (props: any) => {
   const [friendReqEntries, setFriendReqEntries] = useState<Follow[] | undefined>(undefined);
 
   useEffect(() => {
-    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox").then((res: any) => {
+    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/").then((res: any) => {
       const friendReqs: Follow[] = res.data.items.filter((fr: Follow) => { return fr.type === 'follow' });
       setFriendReqEntries(friendReqs);
     })


### PR DESCRIPTION
Right now when axios makes requests, it sees that we get a 301 response and Google Chrome makes a request to that new URL. This might be causing some issues with fetching the inbox.