### PR TITLE
Disable prepend if the post is not Public

### DIFF
--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -141,7 +141,7 @@ export default function CreateEditPostModal(props: Props){
     } else if (res.status >= 200) {
       const post:Post = res.data;
       if(isCreate){
-        if(props.prependToFeed !== undefined && post.visibility === "Public"){
+        if(props.prependToFeed !== undefined && post.visibility === PostVisibility.PUBLIC){
           props.prependToFeed(post)
         }
         resetFormAndToggle()

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -141,7 +141,7 @@ export default function CreateEditPostModal(props: Props){
     } else if (res.status >= 200) {
       const post:Post = res.data;
       if(isCreate){
-        if(props.prependToFeed !== undefined){
+        if(props.prependToFeed !== undefined && post.visibility === "Public"){
           props.prependToFeed(post)
         }
         resetFormAndToggle()


### PR DESCRIPTION
We shouldn't be prepending the post to the feed if the post is not Public. (private posts are sent out to the inboxes of others and should not be visible on the front feed, it is only visible on the Profile feed).