### PR TITLE
Fix links to Followers and Following list on profile page

### DIFF
--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -97,10 +97,10 @@ export default function AuthorPage(props: any) {
     if (props.loggedInUser && author?.id === props.loggedInUser.authorId) {
       return (<>
         <CardText>
-          <Button><CardLink className="text-white" href={"/author/" + props.loggedInUser.authorId + "/followers"}>Followers</CardLink></Button>
+          <Link className="text-white" to={{ pathname: `/author/${props.loggedInUser.authorId}/followers` }}><Button>Followers</Button></Link>
         </CardText>
         <CardText>
-          <Button><CardLink className="text-white" href={"/author/" + props.loggedInUser.authorId + "/following"}>Following</CardLink></Button>
+          <Link className="text-white" to={{ pathname: `/author/${props.loggedInUser.authorId}/following` }}><Button>Following</Button></Link>
         </CardText>
       </>)
     }


### PR DESCRIPTION
Using CardLinks with href to go to the followers and following lists are broken on our netlify instances. I think the issue was that with href, its assuming that it is a path and follows the path /author/authorid/followers and looks for a followers file. Wrapping the button with a Link instead should work since it is using react dom router to change the page. The button do not look any different and actually work better since now you can click anywhere on the button to redirect, instead of actually on the text in the button.

![image](https://user-images.githubusercontent.com/36487188/112704992-6d805c00-8e62-11eb-9d45-6ac3ffee9231.png)


