### PR TITLE
Update wrapper to request for nodes every time it makes a cross-server request

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -8,8 +8,6 @@ import NotFoundPage from './pages/NotFoundPage';
 import AuthPage from './pages/AuthPage';
 import { LoggedInUserContext } from './contexts/LoggedInUserContext';
 import { UserLogin } from './types/UserLogin';
-import { Node } from './types/Node';
-import { AxiosWrapper } from './helpers/AxiosWrapper'
 import AuthorPage from './pages/AuthorPage';
 import SettingsPage from './pages/SettingsPage';
 import CreatePostComponent from './components/CreatePost';
@@ -18,7 +16,6 @@ import PostDetailPage from './pages/PostDetailPage';
 import FollowListPage from './pages/FollowListPage';
 
 const LOCAL_STORAGE_USER = 'loggedInUser';
-const LOCAL_STORAGE_NODES = 'nodes';
 
 /*
 * Snippet based on
@@ -31,60 +28,31 @@ function App() {
   const initialUserState: UserLogin|undefined = initialUserJSON ? JSON.parse(initialUserJSON) : undefined;
   const [loggedInUser,setLoggedInUser] = useState<UserLogin | undefined>(initialUserState);
 
-  const initialNodesJSON = localStorage.getItem(LOCAL_STORAGE_NODES);
-  const initialNodesState: Node[] = initialNodesJSON ? JSON.parse(initialNodesJSON) : [];
-  const [nodes, setNodes] = useState<Node[]>(initialNodesState);
-
   useEffect(()=>{
     if (loggedInUser === undefined){
       localStorage.removeItem(LOCAL_STORAGE_USER);
     } else {
       localStorage.setItem(LOCAL_STORAGE_USER,JSON.stringify(loggedInUser));
-
-      // Already have a Node for our own server.
-      if (nodes.filter(n => n.host === process.env.REACT_APP_API_URL).length !== 0) {
-        return;
-      }
-
-      // Keep track of a Node representing our own server
-      setNodes([...nodes, {
-        host: process.env.REACT_APP_API_URL,
-        username: loggedInUser?.username, 
-        password: loggedInUser?.password
-      } as Node])
     }
-  },[loggedInUser, nodes])
+  },[loggedInUser])
 
-  useEffect(() => {
-    console.log("Nodes: ");
-    console.log(nodes);
-    AxiosWrapper.nodes = nodes;
-    if (nodes.length === 0){
-      localStorage.removeItem(LOCAL_STORAGE_NODES);
-    } else {
-      localStorage.setItem(LOCAL_STORAGE_NODES, JSON.stringify(nodes));
-    }
-  }, [nodes])
-
-  // TODO wrap the below in NodesContext as well, and then use the Nodes in other components.
-  // Talk to Chris about how to use React Context
   return (
     <div>
       <LoggedInUserContext.Provider value={loggedInUser}>
       <BrowserRouter>
         <div>
-          <AppNavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser} setNodes={setNodes} />
+          <AppNavBar loggedInUser={loggedInUser} setLoggedInUser={setLoggedInUser} />
           <Container fluid={true}>
             <Switch>
               <Route exact path="/" render={(props) => <HomePage {...props} loggedInUser={loggedInUser} />} />
-              <Route path="/auth" render={(props) => <AuthPage {...props} setLoggedInUser={setLoggedInUser} setNodes={setNodes}/>} />
+              <Route path="/auth" render={(props) => <AuthPage {...props} setLoggedInUser={setLoggedInUser} />} />
               <Route path="/author/:authorId/followers/" render={(props) => <FollowListPage {...props} loggedInUser={loggedInUser} activeTab={'followers'} />}/>
               <Route path="/author/:authorId/following/" render={(props) => <FollowListPage {...props} loggedInUser={loggedInUser} activeTab={'following'}/>}/>
               <Route path="/author/:authorId" render={(props) => <AuthorPage {...props} loggedInUser={loggedInUser}/>}/>
               {/* TODO: hide settings page if not logged in */}
               <Route path="/settings" render={() => <SettingsPage loggedInUser={loggedInUser} />} />
               <Route path="/create_post" render={(props) => <CreatePostComponent {...props} loggedInUser={loggedInUser} />} />
-              <Route path="/authors/:displayName" render={(props) => <AuthorResultsPage {...props} loggedInUser={loggedInUser} nodes={nodes} />}/>
+              <Route path="/authors/:displayName" render={(props) => <AuthorResultsPage {...props} loggedInUser={loggedInUser} />}/>
               <Route path="/posts/:postId" render={(props) => <PostDetailPage {...props} loggedInUser={loggedInUser}/>}/>
               <Route component={NotFoundPage} />
             </Switch>

--- a/front-end/src/components/AppNavBar.tsx
+++ b/front-end/src/components/AppNavBar.tsx
@@ -8,13 +8,11 @@ import {
 } from "reactstrap";
 import { NavLink } from "react-router-dom";
 import { UserLogin } from "../types/UserLogin";
-import { Node } from "../types/Node";
 import FriendRequestListModal from "./FriendRequestListModal";
 
 interface Props {
   loggedInUser: UserLogin | undefined;
   setLoggedInUser: React.Dispatch<React.SetStateAction<UserLogin | undefined>>;
-  setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
 }
 
 /**
@@ -35,7 +33,6 @@ export default function AppNavBar(props: Props) {
   const close = () => setIsOpen(false);
   const logOut = () => {
     props.setLoggedInUser(undefined);
-    props.setNodes([])
   }
 
   // display pages accessible to a logged in author

--- a/front-end/src/components/AuthorListItem.tsx
+++ b/front-end/src/components/AuthorListItem.tsx
@@ -16,14 +16,14 @@ interface Props {
  * @param props 
  */
 export default function AuthorListItem(props: Props) {
-  const isFollowerUrl = `${props.author.host}api/author/${props.author.id}/followers/${props.loggedInUser?.authorId}`;
+  const isFollowerUrl = `${props.author.host}api/author/${props.author.id}/followers/${props.loggedInUser?.authorId}/`;
 
   const [isFollower, setIsFollower] = useState<boolean>(false);
 
   useEffect(() => {
     // get whether user is follower of author
     if (props.author.id !== props.loggedInUser?.authorId) {
-      AxiosWrapper.get(isFollowerUrl).then((res: any) => {
+      AxiosWrapper.get(isFollowerUrl, props.loggedInUser).then((res: any) => {
         setIsFollower(true);
       }).catch((err: any) => {
         setIsFollower(false);

--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -98,25 +98,25 @@ export default function CreateEditPostModal(props: Props){
       }
 
       if(isCreate){
-        AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/", data)
+        AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/", data, props.loggedInUser)
           .then((post: any) => {
             handleRes(post)
             return post
           }).then((post: any) => {
             if (visibility === PostVisibility.FRIENDS) {
               // send this post to friends only
-              AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/friends/`).then((res: any) => {
+              AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/friends/`, props.loggedInUser).then((res: any) => {
                 let friendsList: Author[] = res.data.items;
                 friendsList.forEach(friend => {
-                  AxiosWrapper.post(`${friend.host}api/author/${friend.id}/inbox/`, post.data);
+                  AxiosWrapper.post(`${friend.host}api/author/${friend.id}/inbox/`, post.data, props.loggedInUser);
                 });
               })
             } else {
               // send this post to all followers (which are friends and followers)
-              AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/followers/`).then((res: any) => {
+              AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser.authorId}/followers/`, props.loggedInUser).then((res: any) => {
                 let followingList: Author[] = res.data.items;
                 followingList.forEach(follower => {
-                  AxiosWrapper.post(`${follower.host}api/author/${follower.id}/inbox/`, post.data);
+                  AxiosWrapper.post(`${follower.host}api/author/${follower.id}/inbox/`, post.data, props.loggedInUser);
                 });
               });
             }
@@ -125,7 +125,7 @@ export default function CreateEditPostModal(props: Props){
           })
       }
       else if(props.editFields !== undefined){
-          AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.editFields.id + "/", data)
+          AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.editFields.id + "/", data, props.loggedInUser)
           .then((res: any) => {
             handleRes(res)
           }).catch((err: any) => {

--- a/front-end/src/components/CreatePost.tsx
+++ b/front-end/src/components/CreatePost.tsx
@@ -48,7 +48,7 @@ const CreatePostComponent = (props: any) => {
             content: content,
             categories: categories
         }
-        AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/", data)
+        AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/", data, props.loggedInUser)
         .then((res: any) => {
             if (res.status >= 400) {
                 setShowError(true)

--- a/front-end/src/components/DeleteModal.tsx
+++ b/front-end/src/components/DeleteModal.tsx
@@ -24,7 +24,7 @@ export default function DeletePostModal(props: Props){
       e.preventDefault();
 
       // Send DELETE request to delete post
-      AxiosWrapper.delete(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.postID)
+      AxiosWrapper.delete(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/posts/" + props.postID, props.loggedInUser)
         .then((res: any) => {
           handleRes(res)
         }).catch((err: any) => {

--- a/front-end/src/components/FriendRequestButton.tsx
+++ b/front-end/src/components/FriendRequestButton.tsx
@@ -17,25 +17,25 @@ export default function FollowRequestButton(props: Props) {
 
   const sendFollowRequest = () => {
     // get the loggedinuser author object
-    AxiosWrapper.get(loggedInUserUrl).then((res: any) => {
+    AxiosWrapper.get(loggedInUserUrl, props.loggedInUser).then((res: any) => {
       if (!props.isFollower) {
-        AxiosWrapper.put(authorUrl, res.data).then((res: any) => {
+        AxiosWrapper.put(authorUrl, res.data, props.loggedInUser).then((res: any) => {
           if (res.status === 201) {
             props.setIsFollower(true);
           }
         });
-        AxiosWrapper.put(followingUrl, props.currentAuthor).then((res: any) => {
+        AxiosWrapper.put(followingUrl, props.currentAuthor, props.loggedInUser).then((res: any) => {
           if (res.status === 201) {
             console.log(props.loggedInUser?.username + " is now following " + props.currentAuthor?.displayName);
           }
         });
       } else {
-        AxiosWrapper.delete(authorUrl).then((res: any) => {
+        AxiosWrapper.delete(authorUrl, props.loggedInUser).then((res: any) => {
           if (res.status === 204) {
             props.setIsFollower(false);
           }
         });
-        AxiosWrapper.delete(followingUrl).then((res: any) => {
+        AxiosWrapper.delete(followingUrl, props.loggedInUser).then((res: any) => {
           if (res.status === 204) {
             console.log("UNFOLLOWED");
           }

--- a/front-end/src/components/FriendRequestListModal.tsx
+++ b/front-end/src/components/FriendRequestListModal.tsx
@@ -9,7 +9,7 @@ const FriendRequestListModal = (props: any) => {
   const [friendReqEntries, setFriendReqEntries] = useState<Follow[] | undefined>(undefined);
 
   useEffect(() => {
-    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/").then((res: any) => {
+    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/", props.loggedInUser).then((res: any) => {
       const friendReqs: Follow[] = res.data.items.filter((fr: Follow) => { return fr.type === 'follow' });
       setFriendReqEntries(friendReqs);
     })

--- a/front-end/src/components/LoginForm.jsx
+++ b/front-end/src/components/LoginForm.jsx
@@ -10,7 +10,7 @@ import {
   Label,
   Input,
 } from 'reactstrap';
-import { AxiosWrapper } from '../helpers/AxiosWrapper';
+import axios from 'axios';
 
 /**
  * Originally from
@@ -33,14 +33,11 @@ export default class LoginForm extends React.Component {
 
   // attempt a login request to the Django server
   attemptLogin(e) {
-    AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/rest-auth/login/", {
+    axios.post(process.env.REACT_APP_API_URL + "/api/rest-auth/login/", {
       username: this.state.username,
       password: this.state.password
     }).then(_ => {
-      return AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/nodes/");
-    }).then(nodes => {
-      this.props.setNodes(nodes.data);
-      return AxiosWrapper.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
+      return axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
     }).then(user => {
       this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id});
       this.props.history.push("/");

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -36,7 +36,7 @@ export default function PostListItem(props: Props) {
   const toggleDelete = () => setIsDeleteModalOpen(!isDeleteModalOpen);
 
   useEffect(() => {
-    AxiosWrapper.get(`${post.author.host}api/author/${post.author.id}/posts/${post.id}/likes/`).then((res: any) => {
+    AxiosWrapper.get(`${post.author.host}api/author/${post.author.id}/posts/${post.id}/likes/`, props.loggedInUser).then((res: any) => {
       const resLikes: Like[] = res.data.items;
       setLikes(resLikes);
       setHasLiked(resLikes.filter((l: Like) => l.author.id === props.loggedInUser?.authorId).length !== 0);
@@ -48,7 +48,7 @@ export default function PostListItem(props: Props) {
       console.error("User is not logged in, cannot like!");
       return;
     }
-    AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/auth-user/${props.loggedInUser.username}`)
+    AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/auth-user/${props.loggedInUser.username}`, props.loggedInUser)
       .then((res: any) => {
         const author: Author = res.data;
         const like: Like = {
@@ -58,7 +58,7 @@ export default function PostListItem(props: Props) {
         }
 
         return AxiosWrapper.post(`${props.post.author.host}api/author/${props.post.author.id}/inbox/`,
-          like
+          like, props.loggedInUser
         )
       }).then((res: any) => {
         alert('You liked the post!');

--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -75,10 +75,6 @@ export default function PostListItem(props: Props) {
       : <CardLink onClick={() => likePost()}>Like</CardLink>
     : null;
 
-  if (!props.loggedInUser) {
-    console.error('You must supply the logged in user if you are editing or deleting!')
-  }
-
   const post: Post = props.post;
   return (
     <div>

--- a/front-end/src/components/RegisterForm.jsx
+++ b/front-end/src/components/RegisterForm.jsx
@@ -11,7 +11,7 @@ import {
   Label,
   Input,
 } from 'reactstrap';
-import { AxiosWrapper } from '../helpers/AxiosWrapper';
+import axios from 'axios';
 
 /**
  * Originally from
@@ -35,15 +35,12 @@ export default class RegisterForm extends React.Component {
 
 
   attemptRegister(e) {
-    AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/rest-auth/registration/", {
+    axios.post(process.env.REACT_APP_API_URL + "/api/rest-auth/registration/", {
       username: this.state.username,
       password1: this.state.password,
       password2: this.state.passwordConf
     }).then(_ => {
-      return AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/nodes/");
-    }).then(nodes => {
-      this.props.setNodes(nodes.data);
-      return AxiosWrapper.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
+      return axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
     }).then(user => {
       this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id});
       this.props.history.push("/");

--- a/front-end/src/helpers/AxiosWrapper.tsx
+++ b/front-end/src/helpers/AxiosWrapper.tsx
@@ -26,6 +26,12 @@ export class AxiosWrapper {
 
   // Given a URL, gets all Nodes from the server and returns a Promise of credentials that should be used to make requests to that URL.
   private static credentials(url: string, user: UserLogin | undefined): Promise<any> {
+    if (AxiosWrapper.isLocal(url)) {
+      return Promise.resolve(user === undefined ? null : { auth: { username: user.username, password: user.password } } );
+    } else {
+      return axios.get<Node[]>(AxiosWrapper.nodesUrl).then(res => AxiosWrapper.getCredentialsForUrl(url, res.data));
+    }
+
     return AxiosWrapper.isLocal(url) && user !== undefined
       ? Promise.resolve( { auth: { username: user.username, password: user.password } } )
       : axios.get<Node[]>(AxiosWrapper.nodesUrl).then(res => AxiosWrapper.getCredentialsForUrl(url, res.data));

--- a/front-end/src/helpers/AxiosWrapper.tsx
+++ b/front-end/src/helpers/AxiosWrapper.tsx
@@ -27,14 +27,11 @@ export class AxiosWrapper {
   // Given a URL, gets all Nodes from the server and returns a Promise of credentials that should be used to make requests to that URL.
   private static credentials(url: string, user: UserLogin | undefined): Promise<any> {
     if (AxiosWrapper.isLocal(url)) {
-      return Promise.resolve(user === undefined ? null : { auth: { username: user.username, password: user.password } } );
+      let credentials: any = user === undefined ? null : { auth: { username: user.username, password: user.password } };
+      return Promise.resolve(credentials);
     } else {
       return axios.get<Node[]>(AxiosWrapper.nodesUrl).then(res => AxiosWrapper.getCredentialsForUrl(url, res.data));
     }
-
-    return AxiosWrapper.isLocal(url) && user !== undefined
-      ? Promise.resolve( { auth: { username: user.username, password: user.password } } )
-      : axios.get<Node[]>(AxiosWrapper.nodesUrl).then(res => AxiosWrapper.getCredentialsForUrl(url, res.data));
   }
 
   static get(url: string, user: UserLogin | undefined): any {

--- a/front-end/src/helpers/AxiosWrapper.tsx
+++ b/front-end/src/helpers/AxiosWrapper.tsx
@@ -1,15 +1,13 @@
-import { Node } from '../types/Node';
 import axios from 'axios';
+import { Node } from '../types/Node';
+import { UserLogin } from '../types/UserLogin'
 
 export class AxiosWrapper {
-  static nodes: Node[] = []
-  
-  /**
-   * Given a URL, checks the host and retrieves the credentials requests to that URL should be made with.
-   * @param url to get the credentials for
-   */
-  private static getCredentialsForUrl(url: string) {
-    let nodes = AxiosWrapper.nodes.filter(n => url.includes(n.host));
+  static readonly nodesUrl = `${process.env.REACT_APP_API_URL}/api/nodes/`;
+
+  // Given a URL and Node[], checks the Nodes and retrieves the credentials that requests to the URL should be made with.
+  private static getCredentialsForUrl(url: string, nodes: Node[]) {
+    nodes = nodes.filter((n: any) => url.includes(n.host));
 
     if (nodes.length === 0) {
       console.log(`No node credentials found for the given request url: ${url}`)
@@ -20,19 +18,32 @@ export class AxiosWrapper {
       : { auth: { username: nodes[0].username, password: nodes[0].password } } ;
   }
 
-  static get(url: string, credentials: any = AxiosWrapper.getCredentialsForUrl(url)): any {
-    return credentials === null ? axios.get(url) : axios.get(url, credentials);
+  // Returns whether or not the given URL contains our back-end API's URL as a substring.
+  // Used to determine whether we need to get extra credentials to make a request or not.
+  private static isLocal(url: string) {
+    return url.includes(process.env.REACT_APP_API_URL as string) ? true : false;
   }
 
-  static delete(url: string, credentials: any = AxiosWrapper.getCredentialsForUrl(url)): any {
-    return credentials === null ? axios.delete(url) : axios.delete(url, credentials);
+  // Given a URL, gets all Nodes from the server and returns a Promise of credentials that should be used to make requests to that URL.
+  private static credentials(url: string, user: UserLogin | undefined): Promise<any> {
+    return AxiosWrapper.isLocal(url) && user !== undefined
+      ? Promise.resolve( { auth: { username: user.username, password: user.password } } )
+      : axios.get<Node[]>(AxiosWrapper.nodesUrl).then(res => AxiosWrapper.getCredentialsForUrl(url, res.data));
   }
 
-  static post(url: string, data: any, credentials: any = AxiosWrapper.getCredentialsForUrl(url)): any {
-    return credentials === null ? axios.post(url, data) : axios.post(url, data, credentials);
+  static get(url: string, user: UserLogin | undefined): any {
+    return AxiosWrapper.credentials(url, user).then(c => c === null ? axios.get(url) : axios.get(url, c));
   }
 
-  static put(url: string, data: any, credentials: any = AxiosWrapper.getCredentialsForUrl(url)): any {
-    return credentials === null ? axios.put(url, data) : axios.put(url, data, credentials);
+  static delete(url: string, user: UserLogin | undefined): any {
+    return AxiosWrapper.credentials(url, user).then(c => c === null ? axios.delete(url) : axios.delete(url, c));
+  }
+
+  static post(url: string, data: any, user: UserLogin | undefined): any {
+    return AxiosWrapper.credentials(url, user).then(c => c === null ? axios.post(url, data) : axios.post(url, data, c));
+  }
+
+  static put(url: string, data: any, user: UserLogin | undefined): any {
+    return AxiosWrapper.credentials(url, user).then(c => c === null ? axios.put(url, data) : axios.put(url, data, c));
   }
 }

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -48,7 +48,7 @@ export default function AuthorPage(props: any) {
     if (props.loggedInUser) {
       // get whether user is follower of author IF not looking at our own profile
       if (!props.location.pathname.includes(props.loggedInUser.authorId)) {
-        AxiosWrapper.get(authorUrl + "/followers/" + props.loggedInUser.authorId, props.loggedInUser).then((res: any) => {
+        AxiosWrapper.get(`${authorUrl}/followers/${props.loggedInUser.authorId}/`, props.loggedInUser).then((res: any) => {
           setIsFollower(true);
         }).catch((err: any) => {
           // 404 is not a follower

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -36,7 +36,7 @@ export default function AuthorPage(props: any) {
 
   // After clicking the profile navlink, get the appropriate author info and data
   useEffect(() => {
-    AxiosWrapper.get(authorUrl).then((res: any) => {
+    AxiosWrapper.get(authorUrl, props.loggedInUser).then((res: any) => {
       const authorOb: Author = res.data;
       setAuthor(authorOb);
       setResponseMessage(200);
@@ -48,7 +48,7 @@ export default function AuthorPage(props: any) {
     if (props.loggedInUser) {
       // get whether user is follower of author IF not looking at our own profile
       if (!props.location.pathname.includes(props.loggedInUser.authorId)) {
-        AxiosWrapper.get(authorUrl + "/followers/" + props.loggedInUser.authorId).then((res: any) => {
+        AxiosWrapper.get(authorUrl + "/followers/" + props.loggedInUser.authorId, props.loggedInUser).then((res: any) => {
           setIsFollower(true);
         }).catch((err: any) => {
           // 404 is not a follower
@@ -56,7 +56,7 @@ export default function AuthorPage(props: any) {
         });
       }
 
-      AxiosWrapper.get(authorUrl + "/posts/").then((res: any) => {
+      AxiosWrapper.get(authorUrl + "/posts/", props.loggedInUser).then((res: any) => {
         const posts: Post[] = res.data;
         setPostEntries(posts);
       }).catch((err: any) => {

--- a/front-end/src/pages/AuthorResultsPage.tsx
+++ b/front-end/src/pages/AuthorResultsPage.tsx
@@ -5,6 +5,7 @@ import { Row, Col } from 'reactstrap';
 import AuthorList from "../components/AuthorList"
 import { Author } from '../types/Author';
 import { Node } from '../types/Node';
+import axios from 'axios';
 
 /**
  * Render list of search results when searching for an author by display name
@@ -20,18 +21,23 @@ export default function AuthorResultsPage(props:any) {
 
   const [authors, setAuthors] = useState<Author[]>([]);
 
+  const authorsUrl = `${process.env.REACT_APP_API_URL}/api/authors/`
+  const nodesUrl = `${process.env.REACT_APP_API_URL}/api/nodes/`;
+
   // get all authors and filter through to find the one we're searching for
   useEffect(() => {
-    // NOTE: Search functionality does not work for users that are not logged in. (they have no Node credentials).
-    let requests = props.nodes.map((n: Node) => {
-      const url = `${n.host}/api/authors/`
-      console.log(`Getting authors from ${url}`);
-      return AxiosWrapper.get(url);
-    })
+    axios.get<Node[]>(nodesUrl).then(res => {
+      let nodes: Node[] = res.data;
+      let externalAuthors = nodes.map((n: Node) => {
+        const url = `${n.host}/api/authors/`
+        console.log(`Getting authors from ${url}`);
+        return AxiosWrapper.get(url, props.loggedInUser);
+      })
 
-    Promise.allSettled(requests).then((results: any) => {
-      let authors = results.filter((r: any) => r.status === "fulfilled").map((r: any) => r.value.data).flat(); 
-      setAuthors(authors.filter((a: Author) => a.displayName === displayName));
+      Promise.allSettled([AxiosWrapper.get(authorsUrl, props.loggedInUser), ...externalAuthors]).then((results: any) => {
+        let authors = results.filter((r: any) => r.status === "fulfilled").map((r: any) => r.value.data).flat(); 
+        setAuthors(authors.filter((a: Author) => a.displayName === displayName));
+      })
     })
   }, []);
 

--- a/front-end/src/pages/FollowListPage.tsx
+++ b/front-end/src/pages/FollowListPage.tsx
@@ -24,13 +24,13 @@ export default function FollowListPage(props: Props) {
 
   // get all followers and following
   useEffect(() => {
-    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser?.authorId + "/followers/").then((res: any) => {
+    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser?.authorId + "/followers/", props.loggedInUser).then((res: any) => {
       console.log(res.data.items)
       const followersList: Author[] = res.data.items;
       setFollowers(followersList);
     });
 
-    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser?.authorId + "/following/").then((res: any) => {
+    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser?.authorId + "/following/", props.loggedInUser).then((res: any) => {
       console.log(res.data)
       const followingList: Author[] = res.data.items;
       setFollowing(followingList);

--- a/front-end/src/pages/HomePage.tsx
+++ b/front-end/src/pages/HomePage.tsx
@@ -25,7 +25,7 @@ export default function HomePage(props: any) {
 
   // get all public posts
   useEffect(() => {
-    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/public-posts/").then((res: any) => {
+    AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/public-posts/", props.loggedInUser).then((res: any) => {
       const posts: Post[] = res.data;
       setPostEntries(posts);
     }).catch((err: any) => {
@@ -34,7 +34,7 @@ export default function HomePage(props: any) {
 
     // if logged in, get posts from inbox
     if (props.loggedInUser) {
-      AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/").then((res: any) => {
+      AxiosWrapper.get(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser.authorId + "/inbox/", props.loggedInUser).then((res: any) => {
         const inboxPosts: Post[] = res.data.items.filter((p: Post) => { return p.type === 'post' });
         setInboxEntries(inboxPosts);
         const likes: Like[] = res.data.items.filter((p:any) => p.type === 'like');

--- a/front-end/src/pages/PostDetailPage.tsx
+++ b/front-end/src/pages/PostDetailPage.tsx
@@ -1,4 +1,5 @@
 import { AxiosWrapper } from '../helpers/AxiosWrapper';
+import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router';
 import { useParams } from 'react-router-dom';
@@ -28,10 +29,10 @@ export default function PostDetailPage(props: Props) {
   useEffect(() => {
     let getPromise;
     if (props.loggedInUser) {
-      getPromise = AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/posts/${postId}`);
+      getPromise = AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/posts/${postId}`, props.loggedInUser);
     }
     else {
-      getPromise = AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/posts/${props.location.pathname}`,);
+      getPromise = axios.get(`${process.env.REACT_APP_API_URL}/api/posts/${props.location.pathname}`);
     }
     getPromise.then((res: any) => {
       const post: Post = res.data;

--- a/front-end/src/pages/PostDetailPage.tsx
+++ b/front-end/src/pages/PostDetailPage.tsx
@@ -29,10 +29,9 @@ export default function PostDetailPage(props: Props) {
   useEffect(() => {
     let getPromise;
     if (props.loggedInUser) {
-      getPromise = AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/posts/${postId}`, props.loggedInUser);
-    }
-    else {
-      getPromise = axios.get(`${process.env.REACT_APP_API_URL}/api/posts/${props.location.pathname}`);
+      getPromise = AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api/posts/${postId}/`, props.loggedInUser);
+    } else {
+      getPromise = AxiosWrapper.get(`${process.env.REACT_APP_API_URL}/api${props.location.pathname}`, props.loggedInUser);
     }
     getPromise.then((res: any) => {
       const post: Post = res.data;

--- a/front-end/src/pages/SettingsPage.tsx
+++ b/front-end/src/pages/SettingsPage.tsx
@@ -35,7 +35,7 @@ const SettingsPage = (props: Props) => {
 
     // get current author data
     function getAuthorData() {
-        AxiosWrapper.get(authorUrl).then((res: any) => {
+        AxiosWrapper.get(authorUrl, props.loggedInUser).then((res: any) => {
             setUnchangedData(res.data);
         }).catch((err: any) => {
             console.error(err);
@@ -58,7 +58,7 @@ const SettingsPage = (props: Props) => {
             AxiosWrapper.post(authorUrl, {
                 displayName: !displayName ? unchangedData.displayName : displayName,
                 github: !githubUrl ? unchangedData.githubUrl : githubUrl,
-            }).then((res: any) => {
+            }, props.loggedInUser).then((res: any) => {
                 setResponseMessage(res.status);
             }).catch((err: any) => {
                 console.error(err);


### PR DESCRIPTION
The AxiosWrapper now makes a call to `/api/nodes` every single time it gets a URL that requires a cross-server request. If it sees that the URL is local (our own server), then it avoids making this extra /nodes call, and sends the credentials we have for the current UserLogin.

This will prevent us from having to keep track of the nodes client-side, which can run into a lot of race conditions with localStorage. Warning that we still have race conditions with UserLogin being used before it is read from localStorage, but this should be easier to handle than not having the proper Nodes.