### PR TITLE
Removed authentication on authors list endpoint

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_authors.py
+++ b/back-end/api/quickstart/tests/endpoints/test_authors.py
@@ -11,9 +11,6 @@ client = APIClient()
 class GetAuthorById(TestCase):
   """Tests for getting all Authors at endpoint /api/authors/."""
 
-  def setUp(self):
-    client.force_authenticate(User.objects.create(username='john', password='doe'))
-
   def test_get_authors(self):
     for i in range(3):
       Author.objects.create(**get_test_author_fields())

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -29,8 +29,7 @@ class AuthorsViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows getting all authors.
     """
-    authentication_classes = [BasicAuthentication]
-    permission_classes = [IsAuthenticated]
+    # DO NOT AUTHENTICATION UNTIL DEEMED SAFE WITH OTHER GROUPS AFTER DEMOS
     queryset = Author.objects.all()
     serializer_class = AuthorSerializer
     lookup_field = 'id'


### PR DESCRIPTION
Currently Amy's group did not expect us to authenticate the authors list endpoint. The plan is to remove authentication on this endpoint until their demo is over and it is safe to put authentication back in.