### PR TITLE
Update author search to expect trailing slash from nodes.

### DIFF
--- a/front-end/src/pages/AuthorResultsPage.tsx
+++ b/front-end/src/pages/AuthorResultsPage.tsx
@@ -29,7 +29,7 @@ export default function AuthorResultsPage(props:any) {
     axios.get<Node[]>(nodesUrl).then(res => {
       let nodes: Node[] = res.data;
       let externalAuthors = nodes.map((n: Node) => {
-        const url = `${n.host}/api/authors/`
+        const url = `${n.host}api/authors/`
         console.log(`Getting authors from ${url}`);
         return AxiosWrapper.get(url, props.loggedInUser);
       })


### PR DESCRIPTION
Currently "host" seems to mean with the trailing slash (Author JSON in the requirements spec includes the trailing slash).

I've changed this request to expect that, meaning that in the back-end, we should save Node hosts with the trailing slash. This helps us stay consistent with other cross server requests.