### PR TITLE
Changed PUT endpoint for follower to match other teams input.

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_followers.py
+++ b/back-end/api/quickstart/tests/endpoints/test_followers.py
@@ -58,11 +58,16 @@ class CreateFollow(TestCase):
     self.inbox = Inbox.objects.create(author=self.receiver)
     self.sender = get_follow_author_fields()
     self.sender_id = self.sender["id"]
+    self.object = {
+      "type": "follow",
+      "actor": self.sender,
+      "object": AuthorSerializer(self.receiver).data
+    }
 
   def test_create_follow(self):
     response = client.put(
       f'/api/author/{self.receiver.id}/followers/{self.sender_id}/',
-      data=json.dumps(self.sender),
+      data=json.dumps(self.object),
       content_type='application/json'
     )
     self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -243,16 +243,12 @@ class FollowersViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     def create(self, request, receiver, sender):
         try:
             author = Author.objects.get(id=receiver)
-            Follow.objects.create(receiver=author, sender=request.data)
+            Follow.objects.create(receiver=author, sender=request.data["actor"])
         except Author.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         # Save this follow to the inbox of the receiver as well
-        friend_req = {
-            'type': 'follow',
-            'actor': request.data,
-            'object': AuthorSerializer(author).data
-        }
+        friend_req = request.data
         inbox = Inbox.objects.get(author=receiver)
         inbox.items.append(friend_req)
         inbox.save()


### PR DESCRIPTION
One of our groups that we are working, when PUTing to the follow endpoint, they are sending a friend request json which contains both the sender and the reciever and a type follow. This is different from what we were doing originally, which was just expecting the author object of the sender.