### PR TITLE
Updated front end to PUT the friend object that other teams are expecting

### DIFF
--- a/front-end/src/components/FriendRequestButton.tsx
+++ b/front-end/src/components/FriendRequestButton.tsx
@@ -19,7 +19,12 @@ export default function FollowRequestButton(props: Props) {
     // get the loggedinuser author object
     AxiosWrapper.get(loggedInUserUrl, props.loggedInUser).then((res: any) => {
       if (!props.isFollower) {
-        AxiosWrapper.put(authorUrl, res.data, props.loggedInUser).then((res: any) => {
+        let followObject = {
+          type: "follow",
+          actor: res.data,
+          object: props.currentAuthor
+        }
+        AxiosWrapper.put(authorUrl, followObject, props.loggedInUser).then((res: any) => {
           if (res.status === 201) {
             props.setIsFollower(true);
           }


### PR DESCRIPTION
Front end now sends a friend request object to conform to what other groups are expecting to change and now what our backend expects as well.

example:
```
{
    "type": "follow",      
    "actor":{
        "type":"author",
        "id":"http://127.0.0.1:5454/author/1d698d25ff008f7538453c120f581471",
        "url":"http://127.0.0.1:5454/author/1d698d25ff008f7538453c120f581471",
        "host":"http://127.0.0.1:5454/",
        "displayName":"Greg Johnson",
        "github": "http://github.com/gjohnson"
    },
    "object":{
        "type":"author",
        # ID of the Author
        "id":"http://127.0.0.1:5454/author/9de17f29c12e8f97bcbbd34cc908f1baba40658e",
        # the home host of the author
        "host":"http://127.0.0.1:5454/",
        # the display name of the author
        "displayName":"Lara Croft",
        # url to the authors profile
        "url":"http://127.0.0.1:5454/author/9de17f29c12e8f97bcbbd34cc908f1baba40658e",
        # HATEOS url for Github API
        "github": "http://github.com/laracroft"
    }
}
```