### PR TITLE
Disable prepend to public feed if post is unlisted

### DIFF
--- a/front-end/src/components/CreateEditPostModal.tsx
+++ b/front-end/src/components/CreateEditPostModal.tsx
@@ -133,7 +133,7 @@ export default function CreateEditPostModal(props: Props){
     if (ResponseHelper.isSuccess(res)) {
       const post:Post = res.data;
       if(isCreate){
-        if(props.prependToFeed !== undefined && post.visibility === PostVisibility.PUBLIC){
+        if(props.prependToFeed !== undefined && post.visibility === PostVisibility.PUBLIC && !post.unlisted){
           props.prependToFeed(post)
         }
         resetFormAndToggle()


### PR DESCRIPTION
Unlisted posts should not show up in the public feed.