### PR TITLE
Make updating GitHub profile easier

### DIFF
--- a/front-end/src/pages/SettingsPage.tsx
+++ b/front-end/src/pages/SettingsPage.tsx
@@ -34,6 +34,9 @@ const SettingsPage = (props: Props) => {
         AxiosWrapper.get(authorUrl, props.loggedInUser).then((res: any) => {
             setDisplayName(res.data.displayName);
             setGithub(res.data.github);
+            const github = res.data.github;
+            // Show only the username part of the Github URL 
+            setGithub(github?.substring(github.lastIndexOf("/") + 1));
         }).catch((err: any) => {
             console.error(err);
             setResponseMessage(500);
@@ -51,7 +54,7 @@ const SettingsPage = (props: Props) => {
         } else {
             AxiosWrapper.post(authorUrl, {
                 displayName,
-                github
+                github: `https://github.com/${github}`
             }, props.loggedInUser).then((res: any) => {
                 setResponseMessage(res.status);
             }).catch((err: any) => {
@@ -91,17 +94,17 @@ const SettingsPage = (props: Props) => {
                         />
                     </FormGroup>
                     <FormGroup>
-                        <Label for="githubUrl">GitHub Account</Label>
+                        <Label for="githubUrl">GitHub Username</Label>
                         <Input
                             type="text" // TODO add URL validation
                             name="githubUrl"
                             id="githubUrl"
-                            placeholder="New GitHub Account"
+                            placeholder="New GitHub Username"
                             onChange={(e) => setGithub(e.target.value)}
                             value={github}
                         />
                         <FormText color="muted">
-                            e.g. https://github.com/yourUsername
+                            e.g. johndoe
                         </FormText>
                     </FormGroup>
                     <FormGroup>

--- a/front-end/src/pages/SettingsPage.tsx
+++ b/front-end/src/pages/SettingsPage.tsx
@@ -33,7 +33,6 @@ const SettingsPage = (props: Props) => {
     useEffect(() => {
         AxiosWrapper.get(authorUrl, props.loggedInUser).then((res: any) => {
             setDisplayName(res.data.displayName);
-            setGithub(res.data.github);
             const github = res.data.github;
             // Show only the username part of the Github URL 
             setGithub(github?.substring(github.lastIndexOf("/") + 1));

--- a/front-end/src/pages/SettingsPage.tsx
+++ b/front-end/src/pages/SettingsPage.tsx
@@ -94,11 +94,11 @@ const SettingsPage = (props: Props) => {
                         />
                     </FormGroup>
                     <FormGroup>
-                        <Label for="githubUrl">GitHub Username</Label>
+                        <Label for="githubUsername">GitHub Username</Label>
                         <Input
                             type="text" // TODO add URL validation
-                            name="githubUrl"
-                            id="githubUrl"
+                            name="githubUsername"
+                            id="githubUsername"
                             placeholder="New GitHub Username"
                             onChange={(e) => setGithub(e.target.value)}
                             value={github}


### PR DESCRIPTION
Now only takes in a username instead of the whole GitHub url. 

![image](https://user-images.githubusercontent.com/11599574/113487577-269ff100-9476-11eb-8218-cd69f9af9945.png)
