### PR TITLE
Fix comment race condition

### DIFF
--- a/front-end/src/components/CommentFormElement.tsx
+++ b/front-end/src/components/CommentFormElement.tsx
@@ -45,11 +45,12 @@ export default function CommentFormElement(props: Props) {
       if (res.status === 200) {
         const author: Author = res.data;
         setCommentAuthor(author);
+        return author;
       }
-    }).then(() => {
-      if (commentAuthor) {
+    }).then((author: any) => {
+      if (author) {
         const comment: PostComment = {
-          author: commentAuthor,
+          author,
           comment: commentContent,
         }
         // Send POST request to comment on a post


### PR DESCRIPTION
Commenting sometimes didn't work, because we were checking commentAuthor state in an if statement, but setCommentAuthor is 
presumably asynchronous. I've fixed this by now returning the author from the Promise so that we can use it as a parameter to .then().
 
![image](https://user-images.githubusercontent.com/11599574/113765892-12f4c480-96da-11eb-8248-8cfd10412004.png)
