### PR TITLE
Return newly created comments from back-end and prepend to feed in front-end

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_comment.py
+++ b/back-end/api/quickstart/tests/endpoints/test_comment.py
@@ -57,5 +57,7 @@ class CreateCommentTest(TestCase):
       content_type='application/json'
     )
 
+    comment = Comment.objects.get(post=self.post)
+    self.assertTrue(comment)
     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-    self.assertTrue(Comment.objects.get(post=self.post))
+    self.assertEqual(response.data, CommentSerializer(comment).data)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -171,11 +171,12 @@ class CommentViewSet(viewsets.ModelViewSet):
     def create(self, request, author, post):
         try:
             postObj = Post.objects.get(id=post)
-            Comment.objects.create(**request.data, post=postObj)
+            comment = Comment.objects.create(**request.data, post=postObj)
+            serializer = CommentSerializer(comment)
         except Post.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        return Response(status=status.HTTP_201_CREATED)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class FriendsListViewSet(viewsets.ModelViewSet):

--- a/front-end/src/components/CommentFormElement.tsx
+++ b/front-end/src/components/CommentFormElement.tsx
@@ -10,7 +10,8 @@ interface Props {
   loggedInUser: UserLogin | undefined,
   postId: string,
   postAuthor: Author,
-  setUpdateComment: Function,
+  commentList: PostComment[] | undefined,
+  setCommentList: Function,
 }
 
 /**
@@ -67,7 +68,9 @@ export default function CommentFormElement(props: Props) {
     if (res.status === 201) {
       // Successfully commented on post, so clear the text box
       setCommentContent("");
-      props.setUpdateComment(comment);
+      if (props.commentList !== undefined) {
+        props.setCommentList([comment, ...props.commentList])
+      }
     } else if (res.status >= 400) {
       // Error in commenting on post
       setShowError(true)

--- a/front-end/src/components/CommentFormElement.tsx
+++ b/front-end/src/components/CommentFormElement.tsx
@@ -55,7 +55,7 @@ export default function CommentFormElement(props: Props) {
         // Send POST request to comment on a post
         AxiosWrapper.post(`${props.postAuthor.host}api/author/${props.postAuthor.id}/posts/${props.postId}/comments/`, comment, props.loggedInUser)
           .then((res: any) => {
-            handleRes(res, comment);
+            handleRes(res, res.data);
           }).catch((err: any) => {
             setShowError(true)
           });
@@ -66,8 +66,10 @@ export default function CommentFormElement(props: Props) {
   function handleRes(res: AxiosResponse, comment: PostComment) {
     if (res.status === 201) {
       // Successfully commented on post, so clear the text box
+      console.log("comment is ");
+      console.log(comment);
       setCommentContent("");
-      props.setUpdateComment(true);
+      props.setUpdateComment(comment);
     } else if (res.status >= 400) {
       // Error in commenting on post
       setShowError(true)

--- a/front-end/src/components/CommentFormElement.tsx
+++ b/front-end/src/components/CommentFormElement.tsx
@@ -66,8 +66,6 @@ export default function CommentFormElement(props: Props) {
   function handleRes(res: AxiosResponse, comment: PostComment) {
     if (res.status === 201) {
       // Successfully commented on post, so clear the text box
-      console.log("comment is ");
-      console.log(comment);
       setCommentContent("");
       props.setUpdateComment(comment);
     } else if (res.status >= 400) {

--- a/front-end/src/components/CommentList.tsx
+++ b/front-end/src/components/CommentList.tsx
@@ -14,7 +14,7 @@ interface Props {
   postAuthor: Author,
   loggedInUser: UserLogin | undefined,
   setUpdateComment: Function,
-  updateComment: boolean,
+  updateComment: PostComment | undefined,
 }
 
 /**
@@ -27,9 +27,8 @@ export default function CommentList(props: Props) {
 
   function fetchComments() {
     AxiosWrapper.get(`${props.postAuthor.url}posts/${props.postId}/comments/`, props.loggedInUser).then((res: any) => {
-      // TODO: filters for friend posts?
       const comments: PostComment[] = res.data;
-      // Reverse the posts so that they are in order (from newest to oldest).
+      // Reverse the comments so that they are in order (from newest to oldest).
       setCommentList(comments.reverse());
     }).catch((err: any) => {
       console.error(err);
@@ -41,8 +40,10 @@ export default function CommentList(props: Props) {
   }, []);
 
   if (props.updateComment) {
-    fetchComments();
     props.setUpdateComment(false);
+    if (commentList !== undefined) {
+      setCommentList([props.updateComment, ...commentList])
+    }
   }
 
   return (

--- a/front-end/src/components/CommentList.tsx
+++ b/front-end/src/components/CommentList.tsx
@@ -1,55 +1,20 @@
-import React, { useEffect, useState } from 'react';
-import { Col, Button, ListGroup, ListGroupItem, ListGroupItemHeading, ListGroupItemText, Card, CardTitle, Container, Row } from 'reactstrap';
-import { UserLogin } from '../types/UserLogin';
-import CreateEditPostModal from '../components/CreateEditPostModal';
-import PostListItem from '../components/PostListItem';
-import { Post } from '../types/Post';
-import { Author } from '../types/Author';
+import { Col, Container } from 'reactstrap';
 import { PostComment } from '../types/PostComment';
 import CommentListItem from './CommentListItem';
-import { AxiosWrapper } from '../helpers/AxiosWrapper';
 
 interface Props {
-  postId: string,
-  postAuthor: Author,
-  loggedInUser: UserLogin | undefined,
-  setUpdateComment: Function,
-  updateComment: PostComment | undefined,
+  commentList: PostComment[] | undefined,
 }
 
 /**
- * Post list component to show list of posts
+ * Post list component to show list of comments
  * @param props 
  */
 export default function CommentList(props: Props) {
-
-  const [commentList, setCommentList] = useState<PostComment[] | undefined>(undefined);
-
-  function fetchComments() {
-    AxiosWrapper.get(`${props.postAuthor.url}posts/${props.postId}/comments/`, props.loggedInUser).then((res: any) => {
-      const comments: PostComment[] = res.data;
-      // Reverse the comments so that they are in order (from newest to oldest).
-      setCommentList(comments.reverse());
-    }).catch((err: any) => {
-      console.error(err);
-    });
-  }
-
-  useEffect(() => {
-    fetchComments();
-  }, []);
-
-  if (props.updateComment) {
-    if (commentList !== undefined) {
-      setCommentList([props.updateComment, ...commentList])
-    }
-    props.setUpdateComment(undefined);
-  }
-
   return (
     <Container fluid>
       <Col>
-        {commentList && commentList.map((c: PostComment) => <CommentListItem comment={c} />)}
+        {props.commentList && props.commentList.map((c: PostComment) => <CommentListItem comment={c} />)}
       </Col>
     </Container>
   );

--- a/front-end/src/components/CommentList.tsx
+++ b/front-end/src/components/CommentList.tsx
@@ -40,10 +40,10 @@ export default function CommentList(props: Props) {
   }, []);
 
   if (props.updateComment) {
-    props.setUpdateComment(false);
     if (commentList !== undefined) {
       setCommentList([props.updateComment, ...commentList])
     }
+    props.setUpdateComment(undefined);
   }
 
   return (

--- a/front-end/src/components/CommentList.tsx
+++ b/front-end/src/components/CommentList.tsx
@@ -1,8 +1,13 @@
 import { Col, Container } from 'reactstrap';
+import { UserLogin } from '../types/UserLogin';
+import { Author } from '../types/Author';
 import { PostComment } from '../types/PostComment';
 import CommentListItem from './CommentListItem';
 
 interface Props {
+  loggedInUser: UserLogin | undefined,
+  postId: string,
+  postAuthor: Author,
   commentList: PostComment[] | undefined,
 }
 

--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -22,7 +22,7 @@ interface Props {
 export default function PostDetailModal(props:Props) {
   const post: Post = props.post;
 
-  const [updateComment, setUpdateComment] = useState(false);
+  const [updateComment, setUpdateComment] = useState<PostComment | undefined>(undefined);
 
   return (
     <Modal isOpen={props.isOpen} toggle={props.toggle} size="lg">

--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import { Post } from '../types/Post';
 import { PostComment } from '../types/PostComment';
@@ -7,6 +7,7 @@ import CommentFormElement from './CommentFormElement';
 import CommentList from './CommentList';
 import PostContent from './PostContentEl';
 import { getDateString } from '../helpers/DateHelper';
+import { AxiosWrapper } from '../helpers/AxiosWrapper';
 
 interface Props {
   post: Post;
@@ -22,7 +23,21 @@ interface Props {
 export default function PostDetailModal(props:Props) {
   const post: Post = props.post;
 
-  const [updateComment, setUpdateComment] = useState<PostComment | undefined>(undefined);
+  const [commentList, setCommentList] = useState<PostComment[] | undefined>(undefined);
+
+  function fetchComments() {
+    AxiosWrapper.get(`${post.author.url}posts/${post.id}/comments/`, props.loggedInUser).then((res: any) => {
+      const comments: PostComment[] = res.data;
+      // Reverse the comments so that they are in order (from newest to oldest).
+      setCommentList(comments.reverse());
+    }).catch((err: any) => {
+      console.error(err);
+    });
+  }
+
+  useEffect(() => {
+    fetchComments();
+  }, []);
 
   return (
     <Modal isOpen={props.isOpen} toggle={props.toggle} size="lg">
@@ -36,9 +51,9 @@ export default function PostDetailModal(props:Props) {
         </div>
       </ModalBody>
       <ModalFooter>
-        <CommentFormElement loggedInUser={props.loggedInUser} postId={post.id} postAuthor={post.author} setUpdateComment={setUpdateComment} />
+        <CommentFormElement loggedInUser={props.loggedInUser} postId={post.id} postAuthor={post.author} commentList={commentList} setCommentList={setCommentList} />
       </ModalFooter>
-      {props.loggedInUser && <ModalFooter><CommentList postId={post.id} postAuthor={post.author} loggedInUser={props.loggedInUser} updateComment={updateComment} setUpdateComment={setUpdateComment}/></ModalFooter>}
+      {props.loggedInUser && <ModalFooter><CommentList commentList={commentList} /></ModalFooter>}
     </Modal>
   );
 }

--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -53,7 +53,7 @@ export default function PostDetailModal(props:Props) {
       <ModalFooter>
         <CommentFormElement loggedInUser={props.loggedInUser} postId={post.id} postAuthor={post.author} commentList={commentList} setCommentList={setCommentList} />
       </ModalFooter>
-      {props.loggedInUser && <ModalFooter><CommentList commentList={commentList} /></ModalFooter>}
+      {props.loggedInUser && <ModalFooter><CommentList loggedInUser={props.loggedInUser} postId={post.id} postAuthor={post.author} commentList={commentList} /></ModalFooter>}
     </Modal>
   );
 }


### PR DESCRIPTION
I've updated the CommentViewSet to return newly created comments, so that the front-end can retrieve this newly created comment (with its ID) and prepend it to the comment list feed. Previously this wasn't doable as pointed out by @raysarinas because liking comments would fail without a proper ID.