### PR TITLE
Fixed up likes for comments

### DIFF
--- a/back-end/api/api/urls.py
+++ b/back-end/api/api/urls.py
@@ -166,7 +166,7 @@ urlpatterns = [
     path('api/author/<str:sender>/following/<str:receiver>/', following, name='following'),
     path('api/author/<str:author>/posts/<str:post>/comments/', comments, name='comments'),
     path('api/author/<str:author>/posts/<str:post>/likes/', likes_post, name='likes-post'),
-    path('api/author/<str:author>/posts/<str:post>/comments/<str:comment>/likes', likes_comment, name='likes-comment'),
+    path('api/author/<str:author>/posts/<str:post>/comments/<str:comment>/likes/', likes_comment, name='likes-comment'),
     path('api/author/<str:author>/liked/', liked, name='liked'),
     path('api/author/<str:author>/inbox/', inbox, name='inbox')
 ]

--- a/back-end/api/quickstart/tests/endpoints/test_likes_comment.py
+++ b/back-end/api/quickstart/tests/endpoints/test_likes_comment.py
@@ -8,7 +8,7 @@ from quickstart.tests.helper_test import get_test_like_fields
 client = Client()
 
 class GetLikesForComment(TestCase):
-  """Tests for getting all likes of a comment at endpoint api/author/<str:author>/posts/<str:post>/comments/<str:comment>/likes."""
+  """Tests for getting all likes of a comment at endpoint api/author/<str:author>/posts/<str:post>/comments/<str:comment>/likes/."""
   def setUp(self):
     self.test_comment_id = 1
     self.like1 = Like.objects.create(**get_test_like_fields(object_id=self.test_comment_id))
@@ -18,7 +18,7 @@ class GetLikesForComment(TestCase):
     self.likes = [self.like1, self.like2]
 
   def test_get_likes_for_comment(self):
-    response = client.get(f'/api/author/authorId/posts/postId/comments/{self.test_comment_id}/likes')
+    response = client.get(f'/api/author/authorId/posts/postId/comments/{self.test_comment_id}/likes/')
 
     likes = Like.objects.filter(object__contains=self.test_comment_id)
     serializer = LikeSerializer(likes, many=True)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -348,7 +348,7 @@ class LikesPostViewSet(viewsets.ModelViewSet):
 
     # TODO: Author is currently being ignored. Do we need to use it?
     def retrieve(self, request, author, post):
-        likes = Like.objects.filter(object__contains=post)
+        likes = Like.objects.filter(object__contains=post).exclude(object__contains="comment")
         serializer = LikeSerializer(likes, many=True)
 
         return Response({


### PR DESCRIPTION
Added trailing slash to like comment endpoint. 

Queries for likes of a post are polluted by likes for comments on that post because the object field for those comments will also include the post id. This pr filters out any likes out that are from comments by excluding any Like that contains the substring comment.