### PR TITLE
Add timestamps to comments

### DIFF
--- a/front-end/src/components/CommentListItem.tsx
+++ b/front-end/src/components/CommentListItem.tsx
@@ -6,6 +6,7 @@ import { UserLogin } from '../types/UserLogin';
 import { PostComment } from '../types/PostComment';
 import { Like } from '../types/Like'
 import { likeButtonIcon, likedButtonIcon } from '../assets/Icons';
+import { getDateString } from '../helpers/DateHelper';
 
 interface Props {
   postId: string,
@@ -57,7 +58,7 @@ export default function CommentListItem(props: Props) {
 
   return (
       <Card>
-          <CardHeader className="mb-2 text-muted"><b>@{props.comment.author.displayName}</b></CardHeader>
+          <CardHeader className="mb-2 text-muted"><b>@{props.comment.author.displayName}</b> {getDateString(props.comment)}</CardHeader>
           <CardBody>
               {props.comment.comment}
               <CardText>🔥{likes.length}</CardText>

--- a/front-end/src/helpers/DateHelper.tsx
+++ b/front-end/src/helpers/DateHelper.tsx
@@ -1,7 +1,6 @@
-import { Post } from "../types/Post";
 import dateformat from "dateformat";
 
-export function getDateString(post: Post) {
-  let date: Date = new Date(post.published);
+export function getDateString(obj: any) {
+  let date: Date = new Date(obj.published);
   return dateformat(date, "dddd, mmmm dS, yyyy, h:MM TT")
 }


### PR DESCRIPTION
Updated the getDateString method to take in any object. Now using this method to show timestamps for comments.

![image](https://user-images.githubusercontent.com/11599574/113929728-9d5a2880-97ad-11eb-8206-86a71602569f.png)
