### PR TITLE
Update AuthorPage to work with cross-server authors

### DIFF
--- a/front-end/src/components/AppNavBar.tsx
+++ b/front-end/src/components/AppNavBar.tsx
@@ -45,7 +45,13 @@ export default function AppNavBar(props: Props) {
         </NavItem>
         <NavItem onClick={close}>
           <NavLink
-            to={`/author/${props.loggedInUser?.authorId}`}
+            to={{
+              pathname: `/author/${props.loggedInUser?.authorId}`,
+              state: {
+                host: props.loggedInUser?.host,
+                id: props.loggedInUser?.authorId
+              }
+            }}
             className="nav-link"
           >
             {Icons.profileIcon} Profile

--- a/front-end/src/components/AuthorSearchBar.tsx
+++ b/front-end/src/components/AuthorSearchBar.tsx
@@ -54,7 +54,13 @@ export default function AuthorSearchBar(props: Props) {
   };
 
   const redirectToAuthor = (author:Author) => {
-    history.push(`/author/${author.id}`);
+    history.push({
+      pathname: `/author/${author.id}/`,
+      state: {
+        host: author.host,
+        id: author.id
+      }
+    });
   }
 
   return (

--- a/front-end/src/components/AuthorSearchBar.tsx
+++ b/front-end/src/components/AuthorSearchBar.tsx
@@ -55,7 +55,7 @@ export default function AuthorSearchBar(props: Props) {
 
   const redirectToAuthor = (author:Author) => {
     history.push({
-      pathname: `/author/${author.id}/`,
+      pathname: `/author/${author.id}`,
       state: {
         host: author.host,
         id: author.id

--- a/front-end/src/components/LoginForm.jsx
+++ b/front-end/src/components/LoginForm.jsx
@@ -39,7 +39,7 @@ export default class LoginForm extends React.Component {
     }).then(_ => {
       return axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
     }).then(user => {
-      this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id});
+      this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id, host: user.data.host});
       this.props.history.push("/");
     }).catch(err => {
       this.setState({loginErr: err.response});

--- a/front-end/src/components/RegisterForm.jsx
+++ b/front-end/src/components/RegisterForm.jsx
@@ -42,7 +42,7 @@ export default class RegisterForm extends React.Component {
     }).then(_ => {
       return axios.get(process.env.REACT_APP_API_URL + `/api/auth-user/${this.state.username}/`);
     }).then(user => {
-      this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id});
+      this.props.setLoggedInUser({username: this.state.username, password: this.state.password, authorId: user.data.id, host: user.data.host});
       this.props.history.push("/");
     }).catch(err => {
       this.setState({registerErr: err.response});

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -35,9 +35,7 @@ interface MatchParams {
  * @param props 
  */
 export default function AuthorPage(props: any) {
-  // TODO: don't use props.location.pathname
-
-  const authorUrl = `${props.location.state.host}api/author/${props.location.state.id}`;
+  const authorUrl = `${props.location.state.host}api/author/${props.location.state.id}/`;
   const [author, setAuthor] = useState<Author | undefined>(undefined);
   const [responseMessage, setResponseMessage] = useState(100);
   const [isFollower, setIsFollower] = useState<boolean>(false);

--- a/front-end/src/pages/AuthorPage.tsx
+++ b/front-end/src/pages/AuthorPage.tsx
@@ -36,7 +36,8 @@ interface MatchParams {
  */
 export default function AuthorPage(props: any) {
   // TODO: don't use props.location.pathname
-  const authorUrl = process.env.REACT_APP_API_URL + "/api" + props.location.pathname;
+
+  const authorUrl = `${props.location.state.host}api/author/${props.location.state.id}`;
   const [author, setAuthor] = useState<Author | undefined>(undefined);
   const [responseMessage, setResponseMessage] = useState(100);
   const [isFollower, setIsFollower] = useState<boolean>(false);

--- a/front-end/src/types/UserLogin.ts
+++ b/front-end/src/types/UserLogin.ts
@@ -2,4 +2,5 @@ export interface UserLogin {
   username: string;
   password: string;
   authorId: string;
+  host: string;
 }


### PR DESCRIPTION
Keeping track of author host upon login/registration. Now when we navigate to the profile page (either by the search bar, or by clicking profile page), we send in author host+id so that we can make a request that also allows for cross server.