### PR TITLE
Re-authenticate GET Inbox and singular Post endpoint

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_inbox.py
+++ b/back-end/api/quickstart/tests/endpoints/test_inbox.py
@@ -13,6 +13,7 @@ client = APIClient()
 class GetInbox(TestCase):
   """Tests to GET an author's inbox at endpoint /api/author/<str:author>/inbox/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.inbox = Inbox.objects.create(author=Author.objects.create(**get_test_author_fields()))
     self.inbox.items.append(get_test_post_fields())
     self.inbox.items.append(get_follow_author_fields())

--- a/back-end/api/quickstart/tests/endpoints/test_posts.py
+++ b/back-end/api/quickstart/tests/endpoints/test_posts.py
@@ -3,16 +3,19 @@ Referenced https://realpython.com/test-driven-development-of-a-django-restful-ap
 import json
 import uuid
 from rest_framework import status
-from django.test import TestCase, Client
+from rest_framework.test import APIClient, force_authenticate
+from django.contrib.auth.models import User
+from django.test import TestCase
 from quickstart.models import Author, Post
 from quickstart.serializers import AuthorSerializer, PostSerializer
 from quickstart.tests.helper_test import get_test_author_fields, get_test_post_fields, get_test_partial_post_fields
 
-client = Client()
+client = APIClient()
 
 class GetPostById(TestCase):
   """Tests for getting a single Post by their ID at endpoint /api/author/{AUTHOR_ID}/posts/{POST_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.author = Author.objects.create(**get_test_author_fields())
     self.post = Post.objects.create(**get_test_post_fields(), author=self.author)
 
@@ -31,6 +34,7 @@ class GetPostById(TestCase):
 class UpdatePostById(TestCase):
   """Tests for updating a single Post by POST'ing to endpoint /author/{AUTHOR_ID}/posts/{POST_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.author = Author.objects.create(**get_test_author_fields())
     self.post = Post.objects.create(**get_test_post_fields(), author=self.author)
 
@@ -74,6 +78,7 @@ class UpdatePostById(TestCase):
 class DeletePostById(TestCase):
   """Tests for deleting a single Post by their ID at endpoint /author/{AUTHOR_ID}/posts/{POST_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.author = Author.objects.create(**get_test_author_fields())
     self.post = Post.objects.create(**get_test_post_fields(), author=self.author)
 
@@ -89,6 +94,7 @@ class DeletePostById(TestCase):
 class CreatePostById(TestCase):
   """Tests for creating a single Post by PUT'ing to endpoint /author/{AUTHOR_ID}/posts/{POST_ID}/."""
   def setUp(self):
+    client.force_authenticate(User.objects.create(username='john', password='doe'))
     self.author = Author.objects.create(**get_test_author_fields())
     self.uuid = uuid.uuid4()
     self.payload = get_test_post_fields()

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -12,7 +12,6 @@ from quickstart.serializers import AuthorSerializer, PostSerializer, FollowSeria
 from .mixins import MultipleFieldLookupMixin
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
-from .permissions import IsAuthenticatedOrGet
 from django.core.paginator import Paginator
 
 
@@ -135,6 +134,8 @@ class PostViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows post to be viewed or edited.
     """
+    authentication_classes = [BasicAuthentication]
+    permission_classes = [IsAuthenticated]
     queryset = Post.objects.all()
     serializer_class = PostSerializer
     lookup_field = 'id'
@@ -398,7 +399,7 @@ class InboxViewSet(viewsets.ModelViewSet):
     API endpoint that allows getting inbox items for an author
     """
     authentication_classes = [BasicAuthentication]
-    permission_classes = [IsAuthenticatedOrGet]
+    permission_classes = [IsAuthenticated]
     queryset = Inbox.objects.all()
     serializer_class = InboxSerializer
     lookup_field = 'author'


### PR DESCRIPTION
We removed auth from the GET Inbox endpoint because we had bugs with AxiosWrapper on the front-end and the Friend Requests tab that was in the app nav bar. AxiosWrapper has since been updated and the FriendRequests tab has been moved into the Inbox, which re-fetches every single time you click it, so re-authing this should be safe.

These two endpoints are authed as per the spec.