### PR TITLE
Fix crash when navigating to profile page from followers/following list

### DIFF
--- a/front-end/src/components/AuthorListItem.tsx
+++ b/front-end/src/components/AuthorListItem.tsx
@@ -51,7 +51,17 @@ export default function AuthorListItem(props: Props) {
             }
           </Col>
           <Col xs="6">
-            <CardTitle tag="h3" ><Link to={{ pathname: `/author/${props.author.id}` }}>{props.author.displayName}</Link></CardTitle>
+            <CardTitle tag="h3" >
+              <Link to=
+                {{ 
+                  pathname: `/author/${props.author.id}`,
+                  state: {
+                    host: props.author.host,
+                    id: props.author.id
+                  }
+                }}>{props.author.displayName}
+              </Link>
+            </CardTitle>
             <CardSubtitle tag="h5">
               {displayFollowButton()}
             </CardSubtitle> 


### PR DESCRIPTION
Needed to send in clicked author's host and ID so that the profile page can make a proper request to get that author's data.