### PR TITLE
Match GET comments with other team

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_comment.py
+++ b/back-end/api/quickstart/tests/endpoints/test_comment.py
@@ -28,7 +28,7 @@ class GetAllCommentsTest(TestCase):
     comments = Comment.objects.filter(post=self.post1)
     serializer = CommentSerializer(comments, many=True)
 
-    self.assertEqual(response.data, serializer.data)
+    self.assertEqual(response.data['items'], serializer.data)
     self.assertEqual(response.status_code, status.HTTP_200_OK)
 
   def test_get_paginated_comments(self):
@@ -37,12 +37,12 @@ class GetAllCommentsTest(TestCase):
 
     response = client.get(f'/api/author/testauthor/posts/{self.post1.id}/comments/?size=5&page=2')
 
-    self.assertEqual(len(response.data), 5)
+    self.assertEqual(len(response.data['items']), 5)
 
   def test_get_empty_comments(self):
     response = client.get(f'/api/author/testauthor/posts/{self.post3.id}/comments/')
 
-    self.assertEqual(response.data, [])
+    self.assertEqual(response.data['items'], [])
     self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -173,7 +173,10 @@ class CommentViewSet(viewsets.ModelViewSet):
         except EmptyPage:
             return Response(status=status.HTTP_204_NO_CONTENT)
 
-        return Response(serializer.data)
+        return Response({
+            'count': len(queryset),
+            'items': serializer.data
+        })
 
     def create(self, request, author, post):
         try:

--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -31,7 +31,7 @@ export default function PostDetailModal(props:Props) {
   function fetchComments() {
     if (props.loggedInUser !== undefined) {
       AxiosWrapper.get(`${post.author.url}posts/${post.id}/comments/?page=${commentPageNum}`, props.loggedInUser).then((res: any) => {
-        const comments: PostComment[] = res.data;
+        const comments: PostComment[] = res.data.items;
         if (res.status === 204 || comments.length < 5) {
           setNoMoreComments(true);
         }


### PR DESCRIPTION
Anas' team wanted to have the response of GETing comments to be like:
```json
{
    "count": 1023,
    "items": [
       …
    ]
}
```
Changed test and frontend to match these changes to the response