### PR TITLE
Make GitHub feed show create PR events only, update UI

### DIFF
--- a/front-end/src/components/GithubFeed.tsx
+++ b/front-end/src/components/GithubFeed.tsx
@@ -21,8 +21,9 @@ export default function GithubFeed(props: Props) {
     const usernameMatches = props.github.match(/https?:\/\/github.com\/(.+)/);
     // console.log(usernameMatches, usernameMatches?.length !== undefined, usernameMatches?.length === 2);
     if (usernameMatches && usernameMatches.length === 2){
-      axios.get(`https://api.github.com/users/${usernameMatches[1]}/events`).then((res) => {
-        setGithubEvents(res.data)
+      axios.get(`https://api.github.com/users/${usernameMatches[1]}/events?per_page=100`).then((res) => {
+        let prOpenedEvents = res.data.filter((e: any) => e.type === "PullRequestEvent" && e.payload.action === "opened");
+        setGithubEvents(prOpenedEvents)
       });
     } else {
       setError("The github url provided isn't valid :(");

--- a/front-end/src/components/GithubFeedItem.tsx
+++ b/front-end/src/components/GithubFeedItem.tsx
@@ -9,7 +9,7 @@ interface Props {
  * github list event component to show the author's github events
  * @param props
  */
-export default function LikeListItem(props: Props) {
+export default function GithubFeedItem(props: Props) {
   const prUrl = `https://github.com/${props.githubEvent.repo.name}/pull/${props.githubEvent.payload.number}`;
 
   return (

--- a/front-end/src/components/GithubFeedItem.tsx
+++ b/front-end/src/components/GithubFeedItem.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody } from "reactstrap";
+import { Card, CardBody, CardSubtitle } from "reactstrap";
 import { GithubEvent } from "../types/Github";
 
 interface Props {
@@ -10,11 +10,16 @@ interface Props {
  * @param props
  */
 export default function LikeListItem(props: Props) {
+  const prUrl = `https://github.com/${props.githubEvent.repo.name}/pull/${props.githubEvent.payload.number}`;
+
   return (
     <Card>
-      <CardBody>
-        <p>Performed a {props.githubEvent.type} on the repo {props.githubEvent.repo.name}</p>
+      <CardBody >
+        Created pull request - <a href={prUrl}>{props.githubEvent.payload.pull_request.title}</a>
       </CardBody>
+      <CardSubtitle className="mb-2 text-muted">
+        {props.githubEvent.repo.name}
+      </CardSubtitle>
     </Card>
   )
 }

--- a/front-end/src/components/GithubFeedItem.tsx
+++ b/front-end/src/components/GithubFeedItem.tsx
@@ -15,7 +15,7 @@ export default function LikeListItem(props: Props) {
   return (
     <Card>
       <CardBody >
-        Created pull request - <a href={prUrl}>{props.githubEvent.payload.pull_request.title}</a>
+        <a href={prUrl}>{props.githubEvent.payload.pull_request.title}</a>
       </CardBody>
       <CardSubtitle className="mb-2 text-muted">
         {props.githubEvent.repo.name}

--- a/front-end/src/types/Github.ts
+++ b/front-end/src/types/Github.ts
@@ -4,8 +4,8 @@ export interface GithubEvent {
   id: number,
   // "CreateEvent/PushEvent/DeleteEvent/etc."
   type: string,
-  repo: GithubRepo
-
+  repo: GithubRepo,
+  payload: any
 }
 
 interface GithubRepo {


### PR DESCRIPTION
GitHub feed only gets PullRequestEvents with action: opened now. I also changed the request for events to include page_size of 100, which is the max (https://docs.github.com/en/rest/reference/activity#events). Comparison of the UI below.

**Before:**
![eventsbefore](https://user-images.githubusercontent.com/11599574/114318577-d73b6f80-9aca-11eb-96f7-f3a494035d8c.png)

**After:**
![eventsafter](https://user-images.githubusercontent.com/11599574/114318741-a576d880-9acb-11eb-9770-4a629de94b71.png)

