### PR TITLE
Show alert upon successful reshare

### DIFF
--- a/front-end/src/components/PostListItem.tsx
+++ b/front-end/src/components/PostListItem.tsx
@@ -86,6 +86,8 @@ export default function PostListItem(props: Props) {
       }
       AxiosWrapper.post(process.env.REACT_APP_API_URL + "/api/author/" + props.loggedInUser?.authorId + "/posts/", data, props.loggedInUser)
         .then((res: any) => {
+          alert("You reshared the post!");
+
           post = res.data;
 
           const urlPrefix = `${process.env.REACT_APP_API_URL}/api/author/${props.loggedInUser?.authorId}`;


### PR DESCRIPTION
When the post is successfully created I immediately show the alert. Note that we can move the alert to after we send it to followers' inboxes but this would make the alert quite slow.

![image](https://user-images.githubusercontent.com/11599574/114322177-fe4e6d00-9adb-11eb-9157-764190577b58.png)
