### PR TITLE
Added checks if follow/following exists before creating

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_followers.py
+++ b/back-end/api/quickstart/tests/endpoints/test_followers.py
@@ -75,3 +75,17 @@ class CreateFollow(TestCase):
 
     changed_inbox = Inbox.objects.get(author=self.receiver)
     self.assertTrue(changed_inbox.items[0])
+
+  def test_create_dup_follow(self):
+    client.put(
+      f'/api/author/{self.receiver.id}/followers/{self.sender_id}/',
+      data=json.dumps(self.object),
+      content_type='application/json'
+    )
+
+    response = client.put(
+      f'/api/author/{self.receiver.id}/followers/{self.sender_id}/',
+      data=json.dumps(self.object),
+      content_type='application/json'
+    )
+    self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/back-end/api/quickstart/tests/endpoints/test_following.py
+++ b/back-end/api/quickstart/tests/endpoints/test_following.py
@@ -64,3 +64,17 @@ class CreateFollowing(TestCase):
     )
     self.assertEqual(response.status_code, status.HTTP_201_CREATED)
     self.assertTrue(Following.objects.get(receiver=self.receiver, sender=self.sender))
+
+  def test_create_dup_following(self):
+    client.put(
+      f'/api/author/{self.sender.id}/following/{self.receiver_id}/',
+      data=json.dumps(self.receiver),
+      content_type='application/json'
+    )
+
+    response = client.put(
+      f'/api/author/{self.sender.id}/following/{self.receiver_id}/',
+      data=json.dumps(self.receiver),
+      content_type='application/json'
+    )
+    self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -261,6 +261,9 @@ class FollowersViewSet(MultipleFieldLookupMixin, viewsets.ModelViewSet):
     def create(self, request, receiver, sender):
         try:
             author = Author.objects.get(id=receiver)
+            # check if follow already exists
+            if Follow.objects.filter(receiver=author, sender__id=sender).exists():
+                return Response(status=status.HTTP_204_NO_CONTENT)
             Follow.objects.create(receiver=author, sender=request.data["actor"])
         except Author.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
@@ -331,6 +334,9 @@ class FollowingViewSet(viewsets.ModelViewSet):
     def create(self, request, sender, receiver):
         try:
             author = Author.objects.get(id=sender)
+            # check if following already exists
+            if Following.objects.filter(sender=author, receiver__id=receiver).exists():
+                return Response(status=status.HTTP_204_NO_CONTENT)
             Following.objects.create(sender=author, receiver=request.data)
         except Author.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Previously, django would complain about having multiple instances of a follow/following if they were PUT multiple times. Here I added checks to make sure that multiple instances are not created and instead just return a 204 if it already exists.