### PR TITLE
Checked id key exists before iterating for friends

### DIFF
--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -202,7 +202,7 @@ class FriendsListViewSet(viewsets.ModelViewSet):
             friends = []
             for follow in follow_queryset:
                 for following in following_queryset:
-                    if follow.sender["id"] == following.receiver["id"]:
+                    if "id" in follow.sender and "id" in following.receiver and follow.sender["id"] == following.receiver["id"]:
                         friends.append(follow.sender)
                         break
 


### PR DESCRIPTION
Faulty id fields cause a key exception for the friends endpoint. Added in a check to make sure that the key exists.