### PR TITLE
Changed url building for comments to use host instead of url

### DIFF
--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -30,7 +30,7 @@ export default function PostDetailModal(props:Props) {
 
   function fetchComments() {
     if (props.loggedInUser !== undefined) {
-      AxiosWrapper.get(`${post.author.url}posts/${post.id}/comments/?page=${commentPageNum}`, props.loggedInUser).then((res: any) => {
+      AxiosWrapper.get(`${post.author.host}api/author/${post.author.id}/posts/${post.id}/comments/?page=${commentPageNum}`, props.loggedInUser).then((res: any) => {
         const comments: PostComment[] = res.data.items;
         if (res.status === 204 || comments.length < 5) {
           setNoMoreComments(true);


### PR DESCRIPTION
This change makes it consistent with how urls are built elsewhere. Also Anas's team doesn't seem to be sending url in author objects so it breaks xserver as it will be undefined. 