### PR TITLE
Fixed 204 handling for comments

### DIFF
--- a/back-end/api/quickstart/tests/endpoints/test_comment.py
+++ b/back-end/api/quickstart/tests/endpoints/test_comment.py
@@ -41,9 +41,7 @@ class GetAllCommentsTest(TestCase):
 
   def test_get_empty_comments(self):
     response = client.get(f'/api/author/testauthor/posts/{self.post3.id}/comments/')
-
-    self.assertEqual(response.data['items'], [])
-    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 class CreateCommentTest(TestCase):

--- a/back-end/api/quickstart/views.py
+++ b/back-end/api/quickstart/views.py
@@ -168,6 +168,8 @@ class CommentViewSet(viewsets.ModelViewSet):
             paginator = Paginator(queryset, request.GET.get('size', self.page_size))
             page_obj = paginator.page(request.GET.get('page', 1))
             serializer = CommentSerializer(page_obj, many=True)
+            if len(serializer.data) == 0:
+                return Response(status=status.HTTP_204_NO_CONTENT)
         except Post.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
         except EmptyPage:

--- a/front-end/src/components/PostDetailModal.tsx
+++ b/front-end/src/components/PostDetailModal.tsx
@@ -31,8 +31,8 @@ export default function PostDetailModal(props:Props) {
   function fetchComments() {
     if (props.loggedInUser !== undefined) {
       AxiosWrapper.get(`${post.author.host}api/author/${post.author.id}/posts/${post.id}/comments/?page=${commentPageNum}`, props.loggedInUser).then((res: any) => {
-        const comments: PostComment[] = res.data.items;
-        if (res.status === 204 || comments.length < 5) {
+        let comments: PostComment[] = res.status === 204 ? [] : res.data.items;
+        if (comments.length < 5) {
           setNoMoreComments(true);
         }
         if (commentList) {


### PR DESCRIPTION
Fixed backend to send 204 when no comments exist for the page. Also fixed frontend to properly handle 204 if the post is new. When trying to add a comment on a new post with no comments, commentslist is undefined, so when adding a comment, it is not properly appended.