### PR TITLE
Added check for undefined likes response

### DIFF
--- a/front-end/src/components/CommentListItem.tsx
+++ b/front-end/src/components/CommentListItem.tsx
@@ -22,7 +22,7 @@ export default function CommentListItem(props: Props) {
 
   useEffect(() => {
     AxiosWrapper.get(`${props.comment.author.host}api/author/${props.postAuthor.id}/posts/${props.postId}/comments/${props.comment.id}/likes/`, props.loggedInUser).then((res: any) => {
-      const resLikes: Like[] = res.data.items;
+      const resLikes: Like[] = res.data.items === undefined ? [] : res.data.items;
       setLikes(resLikes);
       setHasLiked(resLikes.filter((l: Like) => l.author.id === props.loggedInUser?.authorId).length !== 0);
     })


### PR DESCRIPTION
Anas's team seems to have removed their comment likes endpoint as it wasn't in any of the user stories. Atleast until the presentation, they will not add it back in. 

Trying to hit the endpoint right now will still give us a 200 but will return react code since it is not implemented. I added this check st the frontend does not crash.
 
During the presentation, we should refrain from trying to like comments from post on Anas's server.